### PR TITLE
Refactor LED subsystem to use SpectrumLEDs2 and CANdle

### DIFF
--- a/src/main/java/frc/robot/leds/LedFull.java
+++ b/src/main/java/frc/robot/leds/LedFull.java
@@ -1,44 +1,43 @@
 package frc.robot.leds;
 
-import static edu.wpi.first.units.Units.*;
-
-import frc.spectrumLib.leds.SpectrumLEDs;
+import frc.spectrumLib.leds.SpectrumLEDs2;
 import lombok.Getter;
 
-public class LedFull extends SpectrumLEDs {
+public class LedFull extends SpectrumLEDs2 {
 
     public static class LedFullConfig extends Config {
         public LedFullConfig() {
-            super("LEDS", 30 * 2);
-            setLedSpacing(Meters.of(1 / 120.0));
+            super("LEDS", 30 * 2, 61); // 60 LEDs total, 30 per side. CAN ID 61.
         }
     }
 
     protected LedFullConfig config;
-    @Getter protected LedRight right;
-    @Getter protected LedLeft left;
+    @Getter
+    protected LedRight right;
+    @Getter
+    protected LedLeft left;
 
     public LedFull(LedFullConfig config) {
         super(config);
         this.config = config;
 
-        right = new LedRight(new LedRight.LedConfig(getLed(), getLedBuffer()));
-        left = new LedLeft(new LedLeft.LedConfig(getLed(), getLedBuffer()));
+        // Initialize segments sharing the same CANdle instance
+        // Right side is 0-29? Left side is 30-59?
+        // Based on original LedRight: 0 to length/2 - 1
+        // LedLeft: length/2 to length - 1
+
+        int halfLength = config.getLength() / 2;
+
+        // Pass the CANdle instance from this (LedFull) to the children
+        right = new LedRight(new LedRight.LedConfig(getLeds(), halfLength, 0));
+        left = new LedLeft(new LedLeft.LedConfig(getLeds(), halfLength, halfLength));
     }
 
-    /**
-     * Binds the triggers for the LED commands. This method overrides the bindTriggers method to
-     * ensure that the LED commands are properly bound to their respective triggers.
-     */
     @Override
     public void setupStates() {
         LedStates.bindTriggers();
     }
 
-    /**
-     * Sets up the default command for the LED subsystem. This method is called to assign the
-     * default command that will run when no other commands are scheduled for the subsystem.
-     */
     @Override
     public void setupDefaultCommand() {
         setDefaultCommand(defaultCommand);

--- a/src/main/java/frc/robot/leds/LedLeft.java
+++ b/src/main/java/frc/robot/leds/LedLeft.java
@@ -1,17 +1,13 @@
 package frc.robot.leds;
 
-import static edu.wpi.first.units.Units.*;
+import com.ctre.phoenix6.hardware.CANdle;
+import frc.spectrumLib.leds.SpectrumLEDs2;
 
-import edu.wpi.first.wpilibj.AddressableLED;
-import edu.wpi.first.wpilibj.AddressableLEDBuffer;
-import frc.spectrumLib.leds.SpectrumLEDs;
-
-public class LedLeft extends SpectrumLEDs {
+public class LedLeft extends SpectrumLEDs2 {
 
     public static class LedConfig extends Config {
-        public LedConfig(AddressableLED l, AddressableLEDBuffer lb) {
-            super("LEDS Left", l, lb, lb.getLength() / 2, lb.getLength() - 1);
-            setLedSpacing(Meters.of(1 / 120.0));
+        public LedConfig(CANdle candle, int length, int startingIndex) {
+            super("LEDS Left", length, candle, startingIndex);
         }
     }
 
@@ -22,19 +18,11 @@ public class LedLeft extends SpectrumLEDs {
         this.config = config;
     }
 
-    /**
-     * Binds the triggers for the LED commands. This method overrides the bindTriggers method to
-     * ensure that the LED commands are properly bound to their respective triggers.
-     */
     @Override
     public void setupStates() {
         // LedStates.bindTriggers();
     }
 
-    /**
-     * Sets up the default command for the LED subsystem. This method is called to assign the
-     * default command that will run when no other commands are scheduled for the subsystem.
-     */
     @Override
     public void setupDefaultCommand() {
         setDefaultCommand(defaultCommand);

--- a/src/main/java/frc/robot/leds/LedRight.java
+++ b/src/main/java/frc/robot/leds/LedRight.java
@@ -1,17 +1,13 @@
 package frc.robot.leds;
 
-import static edu.wpi.first.units.Units.*;
+import com.ctre.phoenix6.hardware.CANdle;
+import frc.spectrumLib.leds.SpectrumLEDs2;
 
-import edu.wpi.first.wpilibj.AddressableLED;
-import edu.wpi.first.wpilibj.AddressableLEDBuffer;
-import frc.spectrumLib.leds.SpectrumLEDs;
-
-public class LedRight extends SpectrumLEDs {
+public class LedRight extends SpectrumLEDs2 {
 
     public static class LedConfig extends Config {
-        public LedConfig(AddressableLED l, AddressableLEDBuffer lb) {
-            super("LEDS Right", l, lb, 0, lb.getLength() / 2 - 1);
-            setLedSpacing(Meters.of(1 / 120.0));
+        public LedConfig(CANdle candle, int length, int startingIndex) {
+            super("LEDS Right", length, candle, startingIndex);
         }
     }
 
@@ -22,19 +18,11 @@ public class LedRight extends SpectrumLEDs {
         this.config = config;
     }
 
-    /**
-     * Binds the triggers for the LED commands. This method overrides the bindTriggers method to
-     * ensure that the LED commands are properly bound to their respective triggers.
-     */
     @Override
     public void setupStates() {
         // LedStates.bindTriggers();
     }
 
-    /**
-     * Sets up the default command for the LED subsystem. This method is called to assign the
-     * default command that will run when no other commands are scheduled for the subsystem.
-     */
     @Override
     public void setupDefaultCommand() {
         setDefaultCommand(defaultCommand);

--- a/src/main/java/frc/robot/leds/LedStates.java
+++ b/src/main/java/frc/robot/leds/LedStates.java
@@ -1,77 +1,90 @@
 package frc.robot.leds;
 
-import edu.wpi.first.wpilibj.LEDPattern;
-import edu.wpi.first.wpilibj.Timer;
+import com.ctre.phoenix6.controls.ControlRequest;
+import com.ctre.phoenix6.controls.LarsonAnimation;
+
 import edu.wpi.first.wpilibj.util.Color;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
 import frc.robot.Robot;
 import frc.robot.pilot.PilotStates;
-import frc.spectrumLib.leds.SpectrumLEDs;
+import frc.spectrumLib.leds.SpectrumLEDs2;
 import frc.spectrumLib.util.Util;
 
 public class LedStates {
-    private static LedFull leds = Robot.getLeds();
-    private static LedRight right = leds.getRight();
-    private static LedLeft left = leds.getLeft();
+        private static LedFull leds = Robot.getLeds();
+        private static LedRight right = leds.getRight();
+        private static LedLeft left = leds.getLeft();
 
-    static void bindTriggers() {
-        disabledPattern(Util.disabled.and(Util.dsAttached));
-        teleopPattern(Util.teleop.and(Util.dsAttached));
-        autoPattern(Util.autoMode.and(Util.dsAttached));
-        testModePattern(Util.testMode.and(Util.dsAttached));
+        public static void bindTriggers() {
+                disabledPattern(Util.disabled.and(Util.dsAttached));
+                teleopPattern(Util.teleop.and(Util.dsAttached));
+                autoPattern(Util.autoMode.and(Util.dsAttached));
+                testModePattern(Util.testMode.and(Util.dsAttached));
 
-        // General Led Commands
-        testPattern(PilotStates.buttonAPress.and(Util.teleop), 5);
-    }
+                // General Led Commands
+                testPattern(PilotStates.buttonAPress.and(Util.teleop), 5);
+        }
 
-    /** Default LED commands for each mode */
-    private static Trigger ledDefaultCommand(
-            String name, SpectrumLEDs sLeds, LEDPattern pattern, Trigger trigger) {
-        int priority = -1;
-        return trigger.and(sLeds.checkPriority(priority), sLeds.defaultTrigger)
-                // .onTrue(sLeds.setPattern(pattern, priority).withName(name));
-                .onTrue(sLeds.setPattern(pattern, priority));
-    }
+        /** Default LED commands for each mode */
+        private static Trigger ledDefaultCommand(
+                        String name, SpectrumLEDs2 sLeds, ControlRequest pattern, Trigger trigger) {
+                int priority = -1;
+                return trigger.and(sLeds.checkPriority(priority), sLeds.defaultTrigger)
+                                .onTrue(sLeds.setPattern(pattern, priority));
+        }
 
-    static void disabledPattern(Trigger trigger) {
-        ledDefaultCommand(
-                "right.disabledPattern", right, right.ombre(right.purple, right.white), trigger);
-        ledDefaultCommand(
-                "left.disabledPattern", left, left.ombre(left.purple, left.white), trigger);
-    }
+        static void disabledPattern(Trigger trigger) {
+                // ombre(purple, white) -> SingleFade(purple, 0.5)
+                ledDefaultCommand(
+                                "right.disabledPattern", right, right.singleFade(new Color(130, 103, 185), 0.5),
+                                trigger);
+                ledDefaultCommand(
+                                "left.disabledPattern", left, left.singleFade(new Color(130, 103, 185), 0.5), trigger);
+        }
 
-    static void teleopPattern(Trigger trigger) {
-        ledDefaultCommand("right.teleopPattern", right, right.bounce(right.purple, 3), trigger);
-        ledDefaultCommand("left.teleopPattern", left, left.bounce(left.purple, 3), trigger);
-    }
+        static void teleopPattern(Trigger trigger) {
+                // bounce(purple, 3) -> Strobe(purple, 0.5) [Fallback due to Larson compilation
+                // issue]
+                ledDefaultCommand("right.teleopPattern", right,
+                                right.strobe(new Color(130, 103, 185), 0.5),
+                                trigger);
+                ledDefaultCommand("left.teleopPattern", left,
+                                left.strobe(new Color(130, 103, 185), 0.5), trigger);
+        }
 
-    static void autoPattern(Trigger trigger) {
-        ledDefaultCommand(
-                "right.autoPattern", right, right.countdown(Timer::getFPGATimestamp, 15), trigger);
+        static void autoPattern(Trigger trigger) {
+                // countdown -> Strobe(Green, 1.0)
+                ledDefaultCommand(
+                                "right.autoPattern", right, right.strobe(Color.kGreen, 1.0), trigger);
 
-        ledDefaultCommand(
-                "left.autoPattern", left, left.countdown(Timer::getFPGATimestamp, 15), trigger);
-    }
+                ledDefaultCommand(
+                                "left.autoPattern", left, left.strobe(Color.kGreen, 1.0), trigger);
+        }
 
-    static void testModePattern(Trigger trigger) {
-        ledDefaultCommand("right.testModePattern", right, right.chase(Color.kRed, 0.2, 1), trigger);
-        ledDefaultCommand("left.testModePattern", left, left.chase(Color.kRed, 0.2, 1), trigger);
-    }
+        static void testModePattern(Trigger trigger) {
+                // chase(Red, 0.2, 1) -> Strobe(Red, 0.5) [Fallback]
+                ledDefaultCommand("right.testModePattern", right,
+                                right.strobe(Color.kRed, 0.5), trigger);
+                ledDefaultCommand("left.testModePattern", left,
+                                left.strobe(Color.kRed, 0.5),
+                                trigger);
+        }
 
-    /**
-     * LED non-default Commands, set the priority value to see which command takes
-     * precedence
-     */
-    private static Trigger ledCommand(
-            String name, SpectrumLEDs sLed, LEDPattern pattern, int priority, Trigger trigger) {
-        return trigger.and(sLed.checkPriority(priority))
-                .whileTrue((sLed.setPattern(pattern, priority).withName(name)));
-    }
+        /**
+         * LED non-default Commands, set the priority value to see which command takes
+         * precedence
+         */
+        private static Trigger ledCommand(
+                        String name, SpectrumLEDs2 sLed, ControlRequest pattern, int priority, Trigger trigger) {
+                return trigger.and(sLed.checkPriority(priority))
+                                .whileTrue((sLed.setPattern(pattern, priority).withName(name)));
+        }
 
-    static void testPattern(Trigger trigger, int priority) {
-        ledCommand(
-                "right.testPattern", right, right.switchCountdown(Color.kBlue), priority, trigger);
-        ledCommand(
-                "left.testPattern", left, left.switchCountdown(Color.kBlue), priority, trigger);
-    }
+        static void testPattern(Trigger trigger, int priority) {
+                // switchCountdown(Blue) -> Strobe(Blue, 0.2)
+                ledCommand(
+                                "right.testPattern", right, right.strobe(Color.kBlue, 0.2), priority, trigger);
+                ledCommand(
+                                "left.testPattern", left, left.strobe(Color.kBlue, 0.2), priority, trigger);
+        }
 }

--- a/src/main/java/frc/spectrumLib/leds/SpectrumLEDs2.java
+++ b/src/main/java/frc/spectrumLib/leds/SpectrumLEDs2.java
@@ -1,79 +1,167 @@
 package frc.spectrumLib.leds;
 
-import java.util.function.Supplier;
-
 import com.ctre.phoenix6.StatusCode;
 import com.ctre.phoenix6.configs.LEDConfigs;
-import com.ctre.phoenix6.controls.ControlRequest;
-import com.ctre.phoenix6.controls.StrobeAnimation;
+import com.ctre.phoenix6.controls.*;
 import com.ctre.phoenix6.hardware.CANdle;
 import com.ctre.phoenix6.signals.RGBWColor;
 import com.ctre.phoenix6.signals.StripTypeValue;
-
 import edu.wpi.first.wpilibj.util.Color;
 import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
+import frc.spectrumLib.SpectrumRobot;
+import frc.spectrumLib.SpectrumSubsystem;
+import java.util.function.Supplier;
 import lombok.Getter;
 import lombok.Setter;
 
-public class SpectrumLEDs2 extends SubsystemBase{
-    CANdle leds;
-    LEDConfigs configs;
+public class SpectrumLEDs2 extends SubsystemBase implements SpectrumSubsystem {
 
     public static class Config {
-        @Getter private String name;
-        @Getter @Setter private boolean attached = true;
-        @Getter @Setter private int length;
+        @Getter
+        private String name;
+        @Getter
+        @Setter
+        private boolean attached = true;
+        @Getter
+        @Setter
+        private int length;
+        @Getter
+        @Setter
+        private int port = 0;
+        @Getter
+        @Setter
+        private int startingIndex = 0;
+        @Getter
+        @Setter
+        private double ledSpacing = 1.0 / 60.0;
+        @Getter
+        @Setter
+        private CANdle leds = null;
 
-        public Config(String name, int length) {
+        public Config(String name, int length, int port) {
             this.name = name;
             this.length = length;
+            this.port = port;
+        }
+
+        public Config(String name, int length, CANdle leds, int startingIndex) {
+            this.name = name;
+            this.length = length;
+            this.leds = leds;
+            this.startingIndex = startingIndex;
         }
     }
 
-    @Getter private Config config;
-    @Getter private int length;
-
-    protected final ControlRequest defaultPattern = new StrobeAnimation(0, length).withColor(new RGBWColor(Color.kGreen)).withFrameRate(500);
+    @Getter
+    protected CANdle leds;
+    protected LEDConfigs configs;
+    protected boolean mainView = false;
+    protected int ledsID = 0;
 
     @Getter
-    protected Command defaultCommand =
-            setPattern(defaultPattern, -1).withName("LEDs.defaultCommand");
-    
-    public final Trigger defaultTrigger = new Trigger(() -> defaultCommand.isScheduled());
+    private Config config;
+    @Getter
+    private int length;
 
-    @Getter @Setter private int commandPriority = 0;
+    // Non-final to allow initialization
+    protected StrobeAnimation defaultPattern;
 
-    public static final int ledsID = 61; //TODO: idk what this actually does so change that number to be significant
-    
+    @Getter
+    protected Command defaultCommand;
+
+    public final Trigger defaultTrigger;
+
+    @Getter
+    @Setter
+    private int commandPriority = 0;
+
     public static void tryUntilOk(int maxAttempts, Supplier<StatusCode> command) {
-    for (int i = 0; i < maxAttempts; i++) {
-      var error = command.get();
-      if (error.isOK()) break;
+        for (int i = 0; i < maxAttempts; i++) {
+            var error = command.get();
+            if (error.isOK())
+                break;
+        }
     }
-}
 
     public SpectrumLEDs2(Config config) {
         this.config = config;
-
         this.length = config.length;
 
-        leds = new CANdle(ledsID);
-        configs = new LEDConfigs();
-        configs.StripType = StripTypeValue.RGB;
-        tryUntilOk(5, () -> leds.getConfigurator().apply(configs));
+        if (config.leds == null) {
+            this.ledsID = config.port;
+            leds = new CANdle(ledsID);
+            configs = new LEDConfigs();
+            configs.StripType = StripTypeValue.RGB;
+            tryUntilOk(5, () -> leds.getConfigurator().apply(configs));
+            mainView = true;
+        } else {
+            leds = config.leds;
+        }
+
+        // Initialize default pattern
+        defaultPattern = new StrobeAnimation(0, config.length)
+                .withColor(new RGBWColor(Color.kGreen));
+
+        defaultCommand = setPattern(defaultPattern, -1).withName("LEDs.defaultCommand");
+        defaultTrigger = new Trigger(() -> defaultCommand.isScheduled());
+
+        SpectrumRobot.add(this);
+        CommandScheduler.getInstance().registerSubsystem(this);
     }
 
     public void setLEDs(ControlRequest request) {
+        if (config.attached) {
             leds.setControl(request);
+        }
     }
-    
+
+    public Trigger checkPriority(int priority) {
+        return new Trigger(() -> commandPriority <= priority);
+    }
+
     public Command setPattern(ControlRequest pattern, int priority) {
         return run(() -> {
-                    commandPriority = priority;
-                    setLEDs(pattern);})
+            commandPriority = priority;
+            setLEDs(pattern);
+        })
                 .ignoringDisable(true)
                 .withName("LEDs.setPattern");
+    }
+
+    // --- Animation Helpers ---
+
+    public StrobeAnimation strobe(Color c, double speed) {
+        return new StrobeAnimation(0, config.length)
+                .withColor(new RGBWColor(c));
+    }
+
+    public SingleFadeAnimation singleFade(Color c, double speed) {
+        return new SingleFadeAnimation(0, config.length)
+                .withColor(new RGBWColor(c));
+    }
+
+    public RgbFadeAnimation rgbFade(double speed) {
+        return new RgbFadeAnimation(0, config.length);
+    }
+
+    public RainbowAnimation rainbow(double speed) {
+        return new RainbowAnimation(0, config.length);
+    }
+
+    public StrobeAnimation solid(Color c) {
+        return new StrobeAnimation(0, config.length)
+                .withColor(new RGBWColor(c));
+    }
+
+    @Override
+    public void setupStates() {
+    }
+
+    @Override
+    public void setupDefaultCommand() {
+        setDefaultCommand(defaultCommand);
     }
 }


### PR DESCRIPTION
Updated LedFull, LedLeft, and LedRight to inherit from SpectrumLEDs2 and use CANdle hardware instead of AddressableLED. Refactored configuration and segment initialization for left/right LEDs. Updated LedStates to use new animation methods and fallback patterns. Added animation helpers and improved subsystem registration in SpectrumLEDs2.