### PR TITLE
Limit main.yml to only read permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,8 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     # This grabs the WPILib docker container
     container: wpilib/roborio-cross-ubuntu:2025-24.04


### PR DESCRIPTION
Add permission block to ci, similar to ci in javadoc.yml

The ci shouldnt need the write permissions, as its just testing if the project will build