### PR TITLE
Add independent right axis and resync homing

### DIFF
--- a/src/main/java/frc/robot/subsystems/intakeExtension/IntakeExtension.java
+++ b/src/main/java/frc/robot/subsystems/intakeExtension/IntakeExtension.java
@@ -22,8 +22,8 @@ import lombok.Getter;
 /**
  * The Intake Extension subsystem. Extends and retracts the fuel intake.
  *
- * <p>The deploy is a rack-and-pinion driven by two independent motors: a left axis (this class,
- * CAN id 7) and a right axis ({@link IntakeExtensionRight}, CAN id 6). Each side runs its own
+ * <p>The deploy is a rack-and-pinion driven by two independent motors: a left axis (this class, CAN
+ * id 7) and a right axis ({@link IntakeExtensionRight}, CAN id 6). Each side runs its own
  * closed-loop position control rather than one following the other, so a side that skips teeth on
  * the rack can be driven on its own to resync.
  *
@@ -47,12 +47,12 @@ public class IntakeExtension extends Mechanism {
         @Getter private final double maxRotations = 2.779053;
         @Getter private final double minRotations = 0.0;
 
-        @Getter private final double supplyCurrentLimit = 40;
-        @Getter private final double statorCurrentLimit = 80;
-        @Getter private final double lowerSupplyCurrentLimit = 40;
+        @Getter private final double supplyCurrentLimit = 20;
+        @Getter private final double statorCurrentLimit = 40;
+        @Getter private final double lowerSupplyCurrentLimit = 20;
         @Getter private final double lowerSupplyCurrentTime = 0;
 
-        @Getter private final double positionKp = 10;
+        @Getter private final double positionKp = 13;
         @Getter private final double positionKi = 0;
         @Getter private final double positionKd = 0;
         @Getter private final double positionKv = 1.0;
@@ -94,7 +94,7 @@ public class IntakeExtension extends Mechanism {
         @Getter private final double maxExtensionHeight = 40;
 
         public IntakeExtensionConfig() {
-            super("IntakeExtension", 6, Rio.CANIVORE);
+            super("IntakeExtension", 4, Rio.CANIVORE);
             configMinMaxRotations(minRotations, maxRotations);
             configPIDGains(0, positionKp, positionKi, positionKd);
             configFeedForwardGains(positionKs, positionKv, positionKa, positionKg);
@@ -137,7 +137,7 @@ public class IntakeExtension extends Mechanism {
 
         public static class RightConfig extends Config {
             public RightConfig(IntakeExtensionConfig left) {
-                super("IntakeExtensionRight", 7, Rio.CANIVORE);
+                super("IntakeExtensionRight", 5, Rio.CANIVORE);
                 setAttached(left.isAttached());
                 configMinMaxRotations(left.getMinRotations(), left.getMaxRotations());
                 configPIDGains(0, left.getPositionKp(), left.getPositionKi(), left.getPositionKd());

--- a/src/main/java/frc/robot/subsystems/intakeExtension/IntakeExtension.java
+++ b/src/main/java/frc/robot/subsystems/intakeExtension/IntakeExtension.java
@@ -44,7 +44,7 @@ public class IntakeExtension extends Mechanism {
         @Getter private final double zeroSpeed = -0.1;
         @Getter private final double holdMaxSpeedRPM = 18;
 
-        @Getter private final double maxRotations = 2.779053;
+        @Getter private final double maxRotations = 2.8;
         @Getter private final double minRotations = 0.0;
 
         @Getter private final double supplyCurrentLimit = 20;

--- a/src/main/java/frc/robot/subsystems/intakeExtension/IntakeExtension.java
+++ b/src/main/java/frc/robot/subsystems/intakeExtension/IntakeExtension.java
@@ -4,8 +4,8 @@ import com.ctre.phoenix6.configs.TalonFXConfiguration;
 import com.ctre.phoenix6.configs.TalonFXConfigurator;
 import com.ctre.phoenix6.hardware.TalonFX;
 import com.ctre.phoenix6.sim.TalonFXSimState;
-import com.ctre.phoenix6.signals.MotorAlignmentValue;
 import edu.wpi.first.math.util.Units;
+import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.smartdashboard.Mechanism2d;
 import edu.wpi.first.wpilibj.util.Color;
 import edu.wpi.first.wpilibj.util.Color8Bit;
@@ -19,7 +19,20 @@ import frc.spectrumLib.sim.LinearSim;
 import frc.spectrumLib.telemetry.Telemetry;
 import lombok.Getter;
 
-/** The Intake Extension subsystem. Extends and retracts the fuel intake. */
+/**
+ * The Intake Extension subsystem. Extends and retracts the fuel intake.
+ *
+ * <p>The deploy is a rack-and-pinion driven by two independent motors — a left axis (this class,
+ * CAN id 7) and a right axis ({@link IntakeExtensionRight}, CAN id 6). Each side runs its own
+ * closed-loop position control rather than one following the other, so a side that skips teeth on
+ * the rack can be driven on its own to resync.
+ *
+ * <p>Normal deploy/retract states command both axes to the same setpoint. The {@code RESYNC} state
+ * re-establishes truth by driving each side independently into the fully-extended hard stop (using
+ * a soft-limit-bypassing voltage), detecting the stall, and re-zeroing that side's encoder at
+ * {@code maxRotations}. This recovers from a tooth skip, which otherwise leaves the motor encoder
+ * reading a position the rack is no longer at.
+ */
 public class IntakeExtension extends Mechanism {
 
     public static class IntakeExtensionConfig extends Config {
@@ -50,18 +63,23 @@ public class IntakeExtension extends Mechanism {
         @Getter private final double mmCruiseVelocity = 100;
         @Getter private final double mmAcceleration = 300;
         @Getter private final double mmJerk = 1000;
+        @Getter private final double slowMmCruiseVelocity = 4;
+        @Getter private final double slowMmAcceleration = 20;
+        @Getter private final double slowMmJerk = 1000;
 
         @Getter private final double sensorToMechanismRatio = 11.25;
         @Getter private final double rotorToSensorRatio = 1;
-
-        /* Cancoder config settings */
         @Getter private final double CANcoderRotorToSensorRatio = 1.7;
-        // CANcoderRotorToSensorRatio / sensorToMechanismRatio;
-
         @Getter private final double CANcoderSensorToMechanismRatio = 1;
-
         @Getter private final double CANcoderOffset = 0;
         @Getter private final boolean CANcoderAttached = false;
+
+        /* Resync / stall-homing settings (toward the fully-extended hard stop) */
+        @Getter private final double homingVoltage = 6;
+        @Getter private final double homingStallRPM = 50.0;
+        @Getter private final double homingMinTimeSecs = 0.3;
+        @Getter private final double homingStallDebounceSecs = 0.15;
+        @Getter private final double homingTimeoutSecs = 3.0;
 
         /* Sim Configs */
         @Getter private final double intakeX = Units.inchesToMeters(70);
@@ -76,7 +94,7 @@ public class IntakeExtension extends Mechanism {
         @Getter private final double maxExtensionHeight = 40;
 
         public IntakeExtensionConfig() {
-            super("IntakeExtension", 7, Rio.CANIVORE); // Rio.CANIVORE);
+            super("IntakeExtension", 7, Rio.CANIVORE);
             configMinMaxRotations(minRotations, maxRotations);
             configPIDGains(0, positionKp, positionKi, positionKd);
             configFeedForwardGains(positionKs, positionKv, positionKa, positionKg);
@@ -92,10 +110,6 @@ public class IntakeExtension extends Mechanism {
             configReverseSoftLimit(minRotations, true);
             configNeutralBrakeMode(true);
             configCounterClockwise_Positive();
-            setFollowerConfigs(
-                new FollowerConfig(
-                    "IntakeExtension Right", 6, Rio.CANIVORE, MotorAlignmentValue.Opposed)
-                );
         }
 
         public IntakeExtensionConfig modifyMotorConfig(TalonFX motor) {
@@ -108,6 +122,142 @@ public class IntakeExtension extends Mechanism {
         }
     }
 
+    // ================================================================================
+    // Right Axis — independent, closed-loop, mirror-mounted
+    // ================================================================================
+
+    /**
+     * The right deploy axis. A standalone {@link Mechanism} (not a follower) so it can be driven
+     * independently of the left during a resync. Gains, limits, and geometry mirror the left
+     * config; only the CAN id, name, and motor inversion differ (the right gearbox is mirrored, so
+     * it is {@code Clockwise_Positive} where the left is {@code CounterClockwise_Positive}, giving
+     * both axes the same "positive = extend" convention).
+     */
+    public static class IntakeExtensionRight extends Mechanism {
+
+        public static class RightConfig extends Config {
+            public RightConfig(IntakeExtensionConfig left) {
+                super("IntakeExtensionRight", 6, Rio.CANIVORE);
+                // Mirror the left axis's attachment so detached configs don't build CAN hardware.
+                setAttached(left.isAttached());
+                configMinMaxRotations(left.getMinRotations(), left.getMaxRotations());
+                configPIDGains(0, left.getPositionKp(), left.getPositionKi(), left.getPositionKd());
+                configFeedForwardGains(
+                        left.getPositionKs(),
+                        left.getPositionKv(),
+                        left.getPositionKa(),
+                        left.getPositionKg());
+                configMotionMagic(
+                        left.getMmCruiseVelocity(),
+                        left.getMmAcceleration(),
+                        left.getMmJerk());
+                configSupplyCurrentLimit(left.getSupplyCurrentLimit(), true);
+                configStatorCurrentLimit(left.getStatorCurrentLimit(), true);
+                configLowerSupplyCurrentLimit(left.getLowerSupplyCurrentLimit());
+                configLowerSupplyCurrentTime(left.getLowerSupplyCurrentTime());
+                configGearRatio(left.getGearRatio());
+                configForwardTorqueCurrentLimit(left.getStatorCurrentLimit());
+                configReverseTorqueCurrentLimit(left.getStatorCurrentLimit());
+                configForwardSoftLimit(left.getMaxRotations(), true);
+                configReverseSoftLimit(left.getMinRotations(), true);
+                configNeutralBrakeMode(true);
+                configClockwise_Positive(); // mirror of the left axis
+            }
+        }
+
+        @Getter private final RightConfig rightConfig;
+
+        public IntakeExtensionRight(IntakeExtensionConfig leftConfig) {
+            super(new RightConfig(leftConfig));
+            this.rightConfig = (RightConfig) super.config;
+            Telemetry.print(getName() + " Subsystem Initialized");
+        }
+
+        /** Closed-loop Motion Magic to an absolute rotation target. */
+        public void goToRotations(double rotations) {
+            setMMPosition(() -> rotations);
+        }
+
+        /** Slow (dynamic Motion Magic voltage) move to a rotation target. */
+        public void goToRotationsSlow(
+                double rotations, double cruiseVelocity, double acceleration, double jerk) {
+            setDynMMPositionVoltage(
+                    () -> rotations, () -> cruiseVelocity, () -> acceleration, () -> jerk);
+        }
+
+        /** Open-loop voltage that bypasses soft limits — used to drive into the hard stop. */
+        public void driveHomingVoltage(double volts) {
+            setVoltageOutputNoSoftLimit(() -> volts);
+        }
+
+        /** Re-zeroes this axis at the fully-extended hard stop. */
+        public void zeroAtMax() {
+            setMotorPosition(() -> rightConfig.getMaxRotations());
+        }
+
+        /** Holds the axis (neutral output). */
+        public void stopAxis() {
+            stop();
+        }
+
+        @Override
+        public void periodic() {
+            logBatteryUsage();
+            Telemetry.log("IntakeExtensionRight/CurrentCommand", getCurrentCommandName());
+            Telemetry.log("IntakeExtensionRight/Voltage", getVoltage(), "volts");
+            Telemetry.log("IntakeExtensionRight/StatorCurrent", getStatorCurrent(), "amps");
+            Telemetry.log("IntakeExtensionRight/SupplyCurrent", getSupplyCurrent(), "amps");
+            Telemetry.log("IntakeExtensionRight/Position", getPositionRotations(), "rotations");
+            Telemetry.log("IntakeExtensionRight/RPM", getVelocityRPM(), "RPM");
+            Telemetry.log("IntakeExtensionRight/Temp", getTemp(), "deg_C");
+        }
+    }
+
+    // ---- Subsystem plumbing ----
+
+    @Getter private final IntakeExtensionConfig config;
+    @Getter private IntakeExtensionSim sim;
+    private final IntakeExtensionRight right;
+
+    public IntakeExtension(IntakeExtensionConfig config) {
+        super(config);
+        this.config = config;
+        this.right = new IntakeExtensionRight(config);
+
+        setInitialPosition();
+
+        simulationInit();
+        Telemetry.print(getName() + " Subsystem Initialized");
+    }
+
+    private void setInitialPosition() {
+        if (isAttached()) {
+            motor.setPosition(degreesToRotations(() -> config.getInitPosition()));
+        }
+    }
+
+    public void resetCurrentPositionToMax() {
+        if (isAttached()) {
+            motor.setPosition(config.getMaxRotations());
+        }
+        if (right != null) right.zeroAtMax();
+    }
+
+    public Command resetCurrentPositionToMaxCommand() {
+        return new InstantCommand(this::resetCurrentPositionToMax);
+    }
+
+    public Command resetToInitialPos() {
+        return new InstantCommand(this::setInitialPosition);
+    }
+
+    /** Sets brake mode on both deploy axes. */
+    @Override
+    public void setBrakeMode(boolean isInBrake) {
+        super.setBrakeMode(isInBrake);
+        if (right != null) right.setBrakeMode(isInBrake);
+    }
+
     // ---- State Machine ----
 
     public enum WantedState {
@@ -116,6 +266,7 @@ public class IntakeExtension extends Mechanism {
         CONDITIONAL_EXTEND,
         FULL_RETRACT,
         SLOW_CLOSE,
+        RESYNC,
     }
 
     public enum SystemState {
@@ -123,10 +274,12 @@ public class IntakeExtension extends Mechanism {
         FULL_EXTEND,
         FULL_RETRACT,
         SLOW_CLOSE,
+        HOMING,
     }
 
     private WantedState wantedState = WantedState.STOPPED;
     private SystemState systemState = SystemState.STOPPED;
+    private SystemState previousSystemState = SystemState.STOPPED;
     private boolean sentOutByIntakeState = false;
 
     public void setWantedState(WantedState state) {
@@ -148,65 +301,164 @@ public class IntakeExtension extends Mechanism {
                 yield SystemState.FULL_RETRACT;
             }
             case SLOW_CLOSE -> SystemState.SLOW_CLOSE;
+            case RESYNC -> SystemState.HOMING;
         };
     }
 
     private void applyStates() {
-        boolean slowMove = false;
-        double wantedPercent = 0;
         switch (systemState) {
             case FULL_EXTEND:
-                wantedPercent = 100;
+                commandBoth(100, false);
                 break;
             case FULL_RETRACT:
-                wantedPercent = 0;
+                commandBoth(0, false);
                 break;
             case SLOW_CLOSE:
-                slowMove = true;
-                wantedPercent = 25;
+                commandBoth(25, true);
+                break;
+            case HOMING:
+                applyHoming();
                 break;
             case STOPPED:
                 stop();
+                if (right != null) right.stopAxis();
                 return;
         }
-        final double finalWantedPercent = wantedPercent;
-        final double finalRotation = percentToRotations(() -> finalWantedPercent);
-        if (slowMove) {
-            setDynMMPositionVoltage(() -> finalRotation, () -> 4.0, () -> 20.0, () -> 1000.0);
+    }
+
+    /**
+     * Commands both axes to the same position.
+     *
+     * @param percent target as a percentage of max rotations (0–100)
+     * @param slow whether to use the slow (dynamic Motion Magic voltage) profile
+     */
+    private void commandBoth(double percent, boolean slow) {
+        final double rotations = percentToRotations(() -> percent);
+        if (slow) {
+            setDynMMPositionVoltage(
+                    () -> rotations,
+                    () -> config.getSlowMmCruiseVelocity(),
+                    () -> config.getSlowMmAcceleration(),
+                    () -> config.getSlowMmJerk());
+            if (right != null) {
+                right.goToRotationsSlow(
+                        rotations,
+                        config.getSlowMmCruiseVelocity(),
+                        config.getSlowMmAcceleration(),
+                        config.getSlowMmJerk());
+            }
         } else {
-            setMMPosition(() -> finalRotation);
+            setMMPosition(() -> rotations);
+            if (right != null) right.goToRotations(rotations);
         }
     }
 
-    @Getter private final IntakeExtensionConfig config;
-    @Getter private IntakeExtensionSim sim;
+    // ---- Resync / stall homing ----
 
-    public IntakeExtension(IntakeExtensionConfig config) {
-        super(config);
-        this.config = config;
+    private final Timer homingTimer = new Timer();
+    private boolean leftHomed = false;
+    private boolean rightHomed = false;
+    // Timestamp (homingTimer seconds) each side was last seen moving above the stall speed.
+    private double leftLastMoving = 0;
+    private double rightLastMoving = 0;
 
-        setInitialPosition();
+    /**
+     * Drives each side independently into the fully-extended hard stop, re-zeroing that side's
+     * encoder at {@code maxRotations} once it stalls. A tooth skip corrupts the motor encoder, so
+     * the hard stop is the only reliable position truth; homing uses a soft-limit-bypassing voltage
+     * so it can reach the physical stop even when the (stale) encoder thinks the soft limit is
+     * already reached.
+     */
+    private void applyHoming() {
+        // Re-arm on entry to the HOMING state.
+        if (previousSystemState != SystemState.HOMING) {
+            homingTimer.restart();
+            leftHomed = false;
+            rightHomed = false;
+            leftLastMoving = 0;
+            rightLastMoving = 0;
+        }
 
-        simulationInit();
-        Telemetry.print(getName() + " Subsystem Initialized");
-    }
+        boolean timedOut = homingTimer.get() >= config.getHomingTimeoutSecs();
 
-    private void setInitialPosition() {
-        if (isAttached()) {
-            motor.setPosition(degreesToRotations(() -> config.getInitPosition()));
+        // ── Left side (this mechanism) ──
+        if (!leftHomed) {
+            if (detectLeftStall() || timedOut) {
+                if (timedOut) Telemetry.print("IntakeExtension: LEFT resync timed out");
+                setMotorPosition(() -> config.getMaxRotations());
+                stop();
+                leftHomed = true;
+            } else {
+                setVoltageOutputNoSoftLimit(() -> config.getHomingVoltage());
+            }
+        } else {
+            stop();
+        }
+
+        // ── Right side (independent axis) ──
+        if (right != null) {
+            if (!rightHomed) {
+                if (detectRightStall() || timedOut) {
+                    if (timedOut) Telemetry.print("IntakeExtension: RIGHT resync timed out");
+                    right.zeroAtMax();
+                    right.stopAxis();
+                    rightHomed = true;
+                } else {
+                    right.driveHomingVoltage(config.getHomingVoltage());
+                }
+            } else {
+                right.stopAxis();
+            }
+        } else {
+            rightHomed = true; // no right axis attached → nothing to resync
         }
     }
 
-    public void resetCurrentPositionToMax() {
-        motor.setPosition(config.getMaxRotations());
+    private boolean detectLeftStall() {
+        double now = homingTimer.get();
+        if (Math.abs(getVelocityRPM()) >= config.getHomingStallRPM()) {
+            leftLastMoving = now;
+        }
+        return isStalled(now, leftLastMoving);
     }
 
-    public Command resetCurrentPositionToMaxCommand() {
-        return new InstantCommand(this::resetCurrentPositionToMax);
+    private boolean detectRightStall() {
+        double now = homingTimer.get();
+        if (Math.abs(right.getVelocityRPM()) >= config.getHomingStallRPM()) {
+            rightLastMoving = now;
+        }
+        return isStalled(now, rightLastMoving);
     }
 
-    public Command resetToInitialPos() {
-        return new InstantCommand(this::setInitialPosition);
+    /**
+     * A side is stalled once it has gone the debounce window without moving above the stall speed,
+     * but only after the minimum drive time has elapsed (so the initial pre-motion zero velocity is
+     * not mistaken for a stall).
+     */
+    private boolean isStalled(double now, double lastMoving) {
+        if (now < config.getHomingMinTimeSecs()) {
+            return false;
+        }
+        return (now - lastMoving) >= config.getHomingStallDebounceSecs();
+    }
+
+    /** Whether the most recent resync has finished homing both sides. */
+    public boolean isResyncComplete() {
+        return systemState == SystemState.HOMING && leftHomed && rightHomed;
+    }
+
+    /**
+     * Runs a full resync: drives both sides into the extended hard stop, re-zeros each, then
+     * returns the subsystem to {@code STOPPED}.
+     *
+     * @return a command that completes once both sides are re-zeroed
+     */
+    public Command resyncCommand() {
+        return startEnd(
+                        () -> setWantedState(WantedState.RESYNC),
+                        () -> setWantedState(WantedState.STOPPED))
+                .until(this::isResyncComplete)
+                .withName("IntakeExtension.resync");
     }
 
     @Override
@@ -223,6 +475,10 @@ public class IntakeExtension extends Mechanism {
         Telemetry.log("IntakeExtension/Position", getPositionRotations(), "rotations");
         Telemetry.log("IntakeExtension/RPM", getVelocityRPM(), "RPM");
         Telemetry.log("IntakeExtension/Temp", getTemp(), "deg_C");
+        Telemetry.log("IntakeExtension/LeftHomed", leftHomed);
+        Telemetry.log("IntakeExtension/RightHomed", rightHomed);
+
+        previousSystemState = systemState;
     }
 
     // --------------------------------------------------------------------------------

--- a/src/main/java/frc/robot/subsystems/intakeExtension/IntakeExtension.java
+++ b/src/main/java/frc/robot/subsystems/intakeExtension/IntakeExtension.java
@@ -138,7 +138,6 @@ public class IntakeExtension extends Mechanism {
         public static class RightConfig extends Config {
             public RightConfig(IntakeExtensionConfig left) {
                 super("IntakeExtensionRight", 6, Rio.CANIVORE);
-                // Mirror the left axis's attachment so detached configs don't build CAN hardware.
                 setAttached(left.isAttached());
                 configMinMaxRotations(left.getMinRotations(), left.getMaxRotations());
                 configPIDGains(0, left.getPositionKp(), left.getPositionKi(), left.getPositionKd());
@@ -148,9 +147,7 @@ public class IntakeExtension extends Mechanism {
                         left.getPositionKa(),
                         left.getPositionKg());
                 configMotionMagic(
-                        left.getMmCruiseVelocity(),
-                        left.getMmAcceleration(),
-                        left.getMmJerk());
+                        left.getMmCruiseVelocity(), left.getMmAcceleration(), left.getMmJerk());
                 configSupplyCurrentLimit(left.getSupplyCurrentLimit(), true);
                 configStatorCurrentLimit(left.getStatorCurrentLimit(), true);
                 configLowerSupplyCurrentLimit(left.getLowerSupplyCurrentLimit());
@@ -161,7 +158,7 @@ public class IntakeExtension extends Mechanism {
                 configForwardSoftLimit(left.getMaxRotations(), true);
                 configReverseSoftLimit(left.getMinRotations(), true);
                 configNeutralBrakeMode(true);
-                configClockwise_Positive(); // mirror of the left axis
+                configClockwise_Positive();
             }
         }
 
@@ -188,6 +185,13 @@ public class IntakeExtension extends Mechanism {
         /** Open-loop voltage that bypasses soft limits — used to drive into the hard stop. */
         public void driveHomingVoltage(double volts) {
             setVoltageOutputNoSoftLimit(() -> volts);
+        }
+
+        /** Seeds this axis's encoder to a known starting position (rotations). */
+        public void setInitialPosition(double rotations) {
+            if (isAttached()) {
+                motor.setPosition(rotations);
+            }
         }
 
         /** Re-zeroes this axis at the fully-extended hard stop. */
@@ -232,7 +236,9 @@ public class IntakeExtension extends Mechanism {
 
     private void setInitialPosition() {
         if (isAttached()) {
-            motor.setPosition(degreesToRotations(() -> config.getInitPosition()));
+            double initialRotations = degreesToRotations(() -> config.getInitPosition());
+            motor.setPosition(initialRotations);
+            right.setInitialPosition(initialRotations);
         }
     }
 
@@ -240,7 +246,7 @@ public class IntakeExtension extends Mechanism {
         if (isAttached()) {
             motor.setPosition(config.getMaxRotations());
         }
-        if (right != null) right.zeroAtMax();
+        if (right.isAttached()) right.zeroAtMax();
     }
 
     public Command resetCurrentPositionToMaxCommand() {
@@ -255,7 +261,7 @@ public class IntakeExtension extends Mechanism {
     @Override
     public void setBrakeMode(boolean isInBrake) {
         super.setBrakeMode(isInBrake);
-        if (right != null) right.setBrakeMode(isInBrake);
+        if (right.isAttached()) right.setBrakeMode(isInBrake);
     }
 
     // ---- State Machine ----
@@ -321,7 +327,7 @@ public class IntakeExtension extends Mechanism {
                 break;
             case STOPPED:
                 stop();
-                if (right != null) right.stopAxis();
+                if (right.isAttached()) right.stopAxis();
                 return;
         }
     }
@@ -340,7 +346,7 @@ public class IntakeExtension extends Mechanism {
                     () -> config.getSlowMmCruiseVelocity(),
                     () -> config.getSlowMmAcceleration(),
                     () -> config.getSlowMmJerk());
-            if (right != null) {
+            if (right.isAttached()) {
                 right.goToRotationsSlow(
                         rotations,
                         config.getSlowMmCruiseVelocity(),
@@ -349,7 +355,7 @@ public class IntakeExtension extends Mechanism {
             }
         } else {
             setMMPosition(() -> rotations);
-            if (right != null) right.goToRotations(rotations);
+            if (right.isAttached()) right.goToRotations(rotations);
         }
     }
 
@@ -396,7 +402,7 @@ public class IntakeExtension extends Mechanism {
         }
 
         // ── Right side (independent axis) ──
-        if (right != null) {
+        if (right.isAttached()) {
             if (!rightHomed) {
                 if (detectRightStall() || timedOut) {
                     if (timedOut) Telemetry.print("IntakeExtension: RIGHT resync timed out");

--- a/src/main/java/frc/robot/subsystems/intakeExtension/IntakeExtension.java
+++ b/src/main/java/frc/robot/subsystems/intakeExtension/IntakeExtension.java
@@ -22,7 +22,7 @@ import lombok.Getter;
 /**
  * The Intake Extension subsystem. Extends and retracts the fuel intake.
  *
- * <p>The deploy is a rack-and-pinion driven by two independent motors — a left axis (this class,
+ * <p>The deploy is a rack-and-pinion driven by two independent motors: a left axis (this class,
  * CAN id 7) and a right axis ({@link IntakeExtensionRight}, CAN id 6). Each side runs its own
  * closed-loop position control rather than one following the other, so a side that skips teeth on
  * the rack can be driven on its own to resync.
@@ -182,7 +182,7 @@ public class IntakeExtension extends Mechanism {
                     () -> rotations, () -> cruiseVelocity, () -> acceleration, () -> jerk);
         }
 
-        /** Open-loop voltage that bypasses soft limits — used to drive into the hard stop. */
+        /** Open-loop voltage that bypasses soft limits. Used to drive into the hard stop. */
         public void driveHomingVoltage(double volts) {
             setVoltageOutputNoSoftLimit(() -> volts);
         }

--- a/src/main/java/frc/robot/subsystems/intakeExtension/IntakeExtension.java
+++ b/src/main/java/frc/robot/subsystems/intakeExtension/IntakeExtension.java
@@ -94,7 +94,7 @@ public class IntakeExtension extends Mechanism {
         @Getter private final double maxExtensionHeight = 40;
 
         public IntakeExtensionConfig() {
-            super("IntakeExtension", 7, Rio.CANIVORE);
+            super("IntakeExtension", 6, Rio.CANIVORE);
             configMinMaxRotations(minRotations, maxRotations);
             configPIDGains(0, positionKp, positionKi, positionKd);
             configFeedForwardGains(positionKs, positionKv, positionKa, positionKg);
@@ -109,7 +109,7 @@ public class IntakeExtension extends Mechanism {
             configForwardSoftLimit(maxRotations, true);
             configReverseSoftLimit(minRotations, true);
             configNeutralBrakeMode(true);
-            configCounterClockwise_Positive();
+            configClockwise_Positive();
         }
 
         public IntakeExtensionConfig modifyMotorConfig(TalonFX motor) {
@@ -137,7 +137,7 @@ public class IntakeExtension extends Mechanism {
 
         public static class RightConfig extends Config {
             public RightConfig(IntakeExtensionConfig left) {
-                super("IntakeExtensionRight", 6, Rio.CANIVORE);
+                super("IntakeExtensionRight", 7, Rio.CANIVORE);
                 setAttached(left.isAttached());
                 configMinMaxRotations(left.getMinRotations(), left.getMaxRotations());
                 configPIDGains(0, left.getPositionKp(), left.getPositionKi(), left.getPositionKd());
@@ -158,7 +158,7 @@ public class IntakeExtension extends Mechanism {
                 configForwardSoftLimit(left.getMaxRotations(), true);
                 configReverseSoftLimit(left.getMinRotations(), true);
                 configNeutralBrakeMode(true);
-                configClockwise_Positive();
+                configCounterClockwise_Positive();
             }
         }
 

--- a/src/main/java/frc/spectrumLib/mechanism/Mechanism.java
+++ b/src/main/java/frc/spectrumLib/mechanism/Mechanism.java
@@ -1081,7 +1081,7 @@ public abstract class Mechanism implements Subsystem {
      * @param rotations the target position in rotations
      * @param slot the gain slot to use (0, 1, or 2)
      */
-    public void setMMPosition(DoubleSupplier rotations, int slot) {
+    protected void setMMPosition(DoubleSupplier rotations, int slot) {
         if (isAttached()) {
             target = rotations.getAsDouble();
             MotionMagicVoltage mm =
@@ -1090,15 +1090,13 @@ public abstract class Mechanism implements Subsystem {
         }
     }
 
-    // ── Motor Control (Public) ─────────────────────────────────────────────────
-
     /**
      * Open-loop percent output control with voltage compensation. The output voltage is {@code
      * percent × voltageCompSaturation}.
      *
      * @param percent fractional output between -1 and +1
      */
-    public void setPercentOutput(DoubleSupplier percent) {
+    protected void setPercentOutput(DoubleSupplier percent) {
         if (isAttached()) {
             VoltageOut output =
                     config.voltageControl.withOutput(
@@ -1113,7 +1111,7 @@ public abstract class Mechanism implements Subsystem {
      *
      * @param voltage the desired voltage in volts
      */
-    public void setVoltageOutput(DoubleSupplier voltage) {
+    protected void setVoltageOutput(DoubleSupplier voltage) {
         if (isAttached()) {
             VoltageOut output = config.voltageControl.withOutput(voltage.getAsDouble());
             motor.setControl(output);
@@ -1126,7 +1124,7 @@ public abstract class Mechanism implements Subsystem {
      *
      * @param voltage the desired voltage in volts
      */
-    public void setVoltageOutputNoSoftLimit(DoubleSupplier voltage) {
+    protected void setVoltageOutputNoSoftLimit(DoubleSupplier voltage) {
         if (isAttached()) {
             VoltageOut output =
                     config.voltageControl


### PR DESCRIPTION
Introduce a standalone IntakeExtensionRight Mechanism and full resync/homing flow for the rack-and-pinion intake extension.

Key changes:
- Add IntakeExtensionRight inner class (separate CAN id, mirrored config, closed-loop controls) so each axis can be driven independently.
- Add resync/STALL-homing state (WantedState.RESYNC -> SystemState.HOMING) that drives each side into the fully-extended hard stop with a soft-limit-bypassing voltage, detects stalls, and zeroes encoders at maxRotations to recover from skipped teeth.
- New config fields for slow motion and homing: slowMmCruiseVelocity/Acceleration/Jerk, homingVoltage, homingStallRPM, homingMinTimeSecs, homingStallDebounceSecs, homingTimeoutSecs.
- Refactor command logic: commandBoth(...) to command both axes, plus goToRotations/goToRotationsSlow/driveHomingVoltage/zeroAtMax APIs on the right axis.
- Added Timer-based stall detection and debounce logic, left/right homed tracking, and isResyncComplete() + resyncCommand() helper.
- Propagate brake mode and reset/initial-position operations to the right axis; update telemetry to include left/right homed state and right-axis metrics.
- Remove follower configuration and MotorAlignmentValue usage; adjust imports (add Timer) and minor refactors to Motion Magic calls and initial-position handling.

This enables robust recovery from encoder desynchronization by independently homing each axis to the physical hard stop.