### PR TITLE
ci: add pr.yml to check formatting, compilation, and tests on any PR

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,10 +1,6 @@
-# Runs checks on every pull request, regardless of the target branch.
-# Verifies Java formatting (Spotless), that the code compiles, and runs the
-# unit tests + SpotBugs static analysis.
-
 name: PR Checks
 
-# Triggers on any pull request, no matter what branch it targets.
+# Triggers on any pull request
 on:
   pull_request:
     types: [opened, reopened, synchronize]
@@ -16,28 +12,22 @@ jobs:
   checks:
     runs-on: ubuntu-latest
 
-    # Grabs the WPILib toolchain container (matches main.yml).
     container: wpilib/roborio-cross-ubuntu:2025-24.04
 
     steps:
-      # Checks-out the repository so the job can access it.
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
-      # Declares the repository safe and not under dubious ownership.
+      # Declares the repository safe and not under dubious ownership
       - name: Add repository to git safe directories
         run: git config --global --add safe.directory $GITHUB_WORKSPACE
 
-      # Grant execute permission for gradlew.
+      # Grant execute permission for gradlew
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      # Verify formatting WITHOUT auto-applying it. This runs first/in isolation
-      # because compileJava depends on spotlessApply (see build.gradle), which
-      # would otherwise reformat the sources before the check could catch them.
       - name: Check Java formatting (Spotless)
         run: ./gradlew spotlessCheck
 
-      # Compile the robot code, run unit tests, and run SpotBugs static analysis.
       - name: Compile, test, and analyze
         run: ./gradlew build

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,43 @@
+# Runs checks on every pull request, regardless of the target branch.
+# Verifies Java formatting (Spotless), that the code compiles, and runs the
+# unit tests + SpotBugs static analysis.
+
+name: PR Checks
+
+# Triggers on any pull request, no matter what branch it targets.
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+
+    # Grabs the WPILib toolchain container (matches main.yml).
+    container: wpilib/roborio-cross-ubuntu:2025-24.04
+
+    steps:
+      # Checks-out the repository so the job can access it.
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      # Declares the repository safe and not under dubious ownership.
+      - name: Add repository to git safe directories
+        run: git config --global --add safe.directory $GITHUB_WORKSPACE
+
+      # Grant execute permission for gradlew.
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      # Verify formatting WITHOUT auto-applying it. This runs first/in isolation
+      # because compileJava depends on spotlessApply (see build.gradle), which
+      # would otherwise reformat the sources before the check could catch them.
+      - name: Check Java formatting (Spotless)
+        run: ./gradlew spotlessCheck
+
+      # Compile the robot code, run unit tests, and run SpotBugs static analysis.
+      - name: Compile, test, and analyze
+        run: ./gradlew build


### PR DESCRIPTION
## Summary
Adds a new `.github/workflows/pr.yml` that runs on **every pull request, regardless of target branch** (the existing `main.yml` only fires for PRs into `main`).

## Checks
- **Java formatting (Spotless):** `./gradlew spotlessCheck`, run *first and in isolation*. This is intentional — `build.gradle` has `compileJava.dependsOn spotlessApply`, so if a compile ran first it would auto-reformat the sources and the check would never catch a violation. Running `spotlessCheck` alone (it doesn't trigger compile) makes it a real gate.
- **Compile, test, and analyze:** `./gradlew build` — covers compilation, JUnit tests, and the SpotBugs static analysis already configured in `build.gradle`.

## Notes
- Reuses the existing `main.yml` conventions: WPILib `roborio-cross-ubuntu:2025-24.04` container, `checkout@v6`, git-safe-directory step, and `chmod +x gradlew`.
- Trigger types: `[opened, reopened, synchronize]` with no branch filter.