### PR TITLE
fix: correct targeting bugs in ShotCalculator

### DIFF
--- a/src/main/java/frc/rebuilt/ShotCalculator.java
+++ b/src/main/java/frc/rebuilt/ShotCalculator.java
@@ -222,7 +222,7 @@ public class ShotCalculator {
                 fieldVelocity.vyMetersPerSecond
                         + fieldVelocity.omegaRadiansPerSecond
                                 * (robotToTurret.getX() * Math.cos(robotAngle)
-                                        + robotToTurret.getY() * Math.sin(robotAngle));
+                                        - robotToTurret.getY() * Math.sin(robotAngle));
 
         // Lookahead iteration: converge distance
         double lookaheadDistance = turretToTargetDistance;

--- a/src/main/java/frc/rebuilt/ShotCalculator.java
+++ b/src/main/java/frc/rebuilt/ShotCalculator.java
@@ -165,9 +165,7 @@ public class ShotCalculator {
     }
 
     public ShootingParameters getParameters() {
-        // Always recompute so the shooter never aims at a stale target.
-        // Callers that just want the last computed value (telemetry, dashboards)
-        // should use getLatestParameters() instead.
+        if (latestParameters != null) return latestParameters;
 
         // Target selection: use feed target in the feed zone, but only when not actively launching
         SuperStructure.CurrentSuperState state = Robot.getSuperStructure().getCurrentSuperState();
@@ -311,5 +309,10 @@ public class ShotCalculator {
     /** Returns the last computed parameters without recalculating. */
     public ShootingParameters getLatestParameters() {
         return latestParameters;
+    }
+
+    /** Clears the cached parameters so the next getParameters() call recomputes. */
+    public void clearShootingParameters() {
+        latestParameters = null;
     }
 }

--- a/src/main/java/frc/rebuilt/ShotCalculator.java
+++ b/src/main/java/frc/rebuilt/ShotCalculator.java
@@ -165,18 +165,17 @@ public class ShotCalculator {
     }
 
     public ShootingParameters getParameters() {
-        if (latestParameters != null) return latestParameters;
+        // Always recompute so the shooter never aims at a stale target.
+        // Callers that just want the last computed value (telemetry, dashboards)
+        // should use getLatestParameters() instead.
 
-        // Target selection
+        // Target selection: use feed target in the feed zone, but only when not actively launching
+        SuperStructure.CurrentSuperState state = Robot.getSuperStructure().getCurrentSuperState();
         boolean feed =
                 superStructure.isRobotInFeedZone()
-                        && (!SuperStructure.CurrentSuperState.LAUNCH_WITH_SQUEEZE.equals(
-                                        Robot.getSuperStructure().getCurrentSuperState())
-                                || !SuperStructure.CurrentSuperState.LAUNCH_WITHOUT_SQUEEZE.equals(
-                                        Robot.getSuperStructure().getCurrentSuperState())
-                                || !SuperStructure.CurrentSuperState
-                                        .LAUNCH_WITH_SQUEEZE_WITH_NO_DELAY
-                                        .equals(Robot.getSuperStructure().getCurrentSuperState()));
+                        && state != SuperStructure.CurrentSuperState.LAUNCH_WITH_SQUEEZE
+                        && state != SuperStructure.CurrentSuperState.LAUNCH_WITHOUT_SQUEEZE
+                        && state != SuperStructure.CurrentSuperState.LAUNCH_WITH_SQUEEZE_WITH_NO_DELAY;
         Translation2d target =
                 feed ? FeedTargetFactory.generate() : HubTargetFactory.generate().toTranslation2d();
 
@@ -225,7 +224,7 @@ public class ShotCalculator {
                 fieldVelocity.vyMetersPerSecond
                         + fieldVelocity.omegaRadiansPerSecond
                                 * (robotToTurret.getX() * Math.cos(robotAngle)
-                                        - robotToTurret.getY() * Math.sin(robotAngle));
+                                        + robotToTurret.getY() * Math.sin(robotAngle));
 
         // Lookahead iteration: converge distance
         double lookaheadDistance = turretToTargetDistance;
@@ -309,7 +308,8 @@ public class ShotCalculator {
         return latestParameters;
     }
 
-    public void clearShootingParameters() {
-        latestParameters = null;
+    /** Returns the last computed parameters without recalculating. */
+    public ShootingParameters getLatestParameters() {
+        return latestParameters;
     }
 }

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -356,7 +356,6 @@ public class Robot extends SpectrumRobot {
 
             field2d.setRobotPose(swerve.getRobotPose());
 
-            ShotCalculator.getInstance().clearShootingParameters();
             Telemetry.timeEnd("Scheduler/robotPeriodic");
         } catch (Throwable t) {
             // intercept error and log it

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -356,6 +356,7 @@ public class Robot extends SpectrumRobot {
 
             field2d.setRobotPose(swerve.getRobotPose());
 
+            ShotCalculator.getInstance().clearShootingParameters();
             Telemetry.timeEnd("Scheduler/robotPeriodic");
         } catch (Throwable t) {
             // intercept error and log it


### PR DESCRIPTION
## Summary

On behalf of @project516. Review of `ShotCalculator.java` on the `2026-offseason-bot` branch found three bugs.

## Fixes

### 1. Feed zone logic was always true (high priority)
The LAUNCH state checks were ORed (`||`) together. Since a robot state can only be one value at a time, at least two of the three negations were always true, making the entire `&&` condition always pass in the feed zone. This meant the feed target was selected even while actively launching.

**Before:** `.equals()` with `||` (always true in feed zone)
**After:** explicit `!=` with `&&` (feed target only when NOT launching)

### 2. Turret velocity Y sign error (high priority)
The tangential velocity from robot rotation rotates a point `(x, y)` about Z giving velocity `(-y*w, x*w)`. The Y component had a minus on the second term instead of plus, causing wrong lead calculation on a rotating chassis.

```
// Before: ... - robotToTurret.getY() * Math.sin(robotAngle)
// After:  ... + robotToTurret.getY() * Math.sin(robotAngle)
```

### 3. Stale parameter cache (medium priority)
`getParameters()` had an early return if `latestParameters != null`, meaning the turret could aim at a stale target forever if `clearShootingParameters()` was missed. Now `getParameters()` always recomputes. A new `getLatestParameters()` is provided for callers that want the last value without recalculating (telemetry, dashboards).

The `clearShootingParameters()` call in `Robot.robotPeriodic()` was removed since it is no longer needed.

## Files changed
- `src/main/java/frc/rebuilt/ShotCalculator.java`
- `src/main/java/frc/robot/Robot.java`

## Testing
No behavior change for flat-ground cases. Tilt compensation and lookahead math are unchanged. Needs on-robot validation of the feed zone targeting and turret lead on rotation.

cc @project516