### PR TITLE
fix: rewrite Leds.java to use AddressableLED with WPILib LEDPattern API

### DIFF
--- a/src/main/java/frc/robot/subsystems/leds/Leds.java
+++ b/src/main/java/frc/robot/subsystems/leds/Leds.java
@@ -1,18 +1,19 @@
 package frc.robot.subsystems.leds;
 
-import com.ctre.phoenix6.CANBus;
 import edu.wpi.first.wpilibj.AddressableLED;
 import edu.wpi.first.wpilibj.AddressableLEDBuffer;
 import edu.wpi.first.wpilibj.AddressableLEDBufferView;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.DriverStation.Alliance;
+import edu.wpi.first.wpilibj.LEDPattern;
 import edu.wpi.first.wpilibj.util.Color;
+import edu.wpi.first.units.Units.Seconds;
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
 import frc.rebuilt.ShiftHelpers;
 import frc.robot.Robot;
 import frc.robot.subsystems.SuperStructure;
-import frc.spectrumLib.hardware.Rio;
-import frc.spectrumLib.leds.SpectrumLEDs;
 import frc.spectrumLib.telemetry.Telemetry;
 import frc.spectrumLib.util.Util;
 import lombok.Getter;
@@ -21,95 +22,174 @@ import lombok.Setter;
 /**
  * Robot LED subsystem for the 2026 REBUILT season.
  *
- * <p>Extends {@link SpectrumLEDs} to inherit the full pattern library (solid, stripe, blink,
- * breathe, rainbow, chase, bounce, gradient, ombre, wave, countdown, etc.) and the CANdle hardware
- * abstraction. Robot-specific convenience command methods are defined below; bind them via triggers
- * in {@code Robot.java} or {@code SuperStructure}.
+ * <p>Uses WPILib {@link AddressableLED} to drive a WS2812B-compatible LED strip connected to a
+ * roboRIO PWM port. Patterns are built using the WPILib {@link LEDPattern} API.
  *
- * <p>Hardware: CANdle device ID 1 on the CANivore bus, 20-LED RGB external strip at brightness 0.5.
- * LEDs are disabled on signal loss.
+ * <p>Hardware: PWM port 0, 20-LED RGB strip.
  */
-public class Leds extends SpectrumLEDs {
+public class Leds extends SubsystemBase {
 
     // -------------------------------------------------------------------------
     // Hardware configuration
     // -------------------------------------------------------------------------
 
-    /** Number of external LEDs attached to the CANdle output (indices 8–27 on the device). */
+    /** PWM port on the roboRIO (must be a PWM header, not MXP or DIO). */
+    public static final int LED_PORT = 0;
+
+    /** Number of LEDs on the strip. */
     public static final int NUM_LEDS = 20;
 
-    @Getter @Setter protected AddressableLED led;
-    @Getter @Setter protected AddressableLEDBuffer buffer;
-    @Getter @Setter protected AddressableLEDBufferView view;
+    @Getter @Setter private AddressableLED led;
+    @Getter @Setter private AddressableLEDBuffer ledBuffer;
+    @Getter @Setter private AddressableLEDBufferView ledView;
 
-    public static class LedConfig extends CANdleConfig {
-        @Getter protected String name;
-        @Getter @Setter protected boolean attached = true;
-        @Getter @Setter protected int startingIndex = 0;
-        @Getter @Setter protected int endingIndex = 28;
-        @Getter @Setter protected int port = 0;
+    /** True when this instance owns the LED hardware (created it, not shared). */
+    private boolean mainView = false;
 
-        public LedConfig(
-                String name,
-                AddressableLED l,
-                AddressableLEDBuffer lb,
-                int startingIndex,
-                int endingIndex) {
-            super("Leds", 1, NUM_LEDS, new CANBus(Rio.RIO_CANBUS));
+    // -------------------------------------------------------------------------
+    // Pattern state
+    // -------------------------------------------------------------------------
+
+    @Getter @Setter private int commandPriority = -1;
+    private LEDPattern currentPattern;
+
+    /** Spectrum purple (RGB 130, 103, 185). */
+    public static final Color purple = new Color(130 / 255.0, 103 / 255.0, 185 / 255.0);
+
+    /** Default pattern shown when no command is running. */
+    private final LEDPattern defaultPattern = LEDPattern.solid(purple)
+            .breathe(Seconds.of(2.0));
+
+    // -------------------------------------------------------------------------
+    // Config
+    // -------------------------------------------------------------------------
+
+    public static class LedConfig {
+        @Getter private String name;
+        @Getter @Setter private int port = LED_PORT;
+        @Getter @Setter private int length = NUM_LEDS;
+        @Getter @Setter private int startingIndex = 0;
+        @Getter @Setter private int endingIndex = NUM_LEDS - 1;
+        @Getter @Setter private AddressableLED sharedLed = null;
+        @Getter @Setter private AddressableLEDBuffer sharedBuffer = null;
+
+        public LedConfig(String name) {
             this.name = name;
-            this.led = l;
-            this.buffer = lb;
+        }
+
+        public LedConfig(String name, int port, int length) {
+            this.name = name;
+            this.port = port;
+            this.length = length;
+        }
+
+        public LedConfig(String name, AddressableLED sharedLed, AddressableLEDBuffer sharedBuffer,
+                         int startingIndex, int endingIndex) {
+            this.name = name;
+            this.sharedLed = sharedLed;
+            this.sharedBuffer = sharedBuffer;
             this.startingIndex = startingIndex;
             this.endingIndex = endingIndex;
         }
     }
 
-    @Getter protected LedConfig config;
+    @Getter private LedConfig config;
 
     // -------------------------------------------------------------------------
     // Constructor
     // -------------------------------------------------------------------------
 
     public Leds(LedConfig config) {
-        super(config);
-
         this.config = config;
-        setDefaultCommand(setPattern(breathe(purple, 2.0), -1).withName("Leds.idle"));
 
+        if (config.getSharedLed() == null) {
+            // Own the hardware
+            led = new AddressableLED(config.getPort());
+            ledBuffer = new AddressableLEDBuffer(config.getLength());
+            led.setLength(ledBuffer.getLength());
+            mainView = true;
+        } else {
+            // Share an existing LED + buffer (multi-zone setup)
+            led = config.getSharedLed();
+            ledBuffer = config.getSharedBuffer();
+            mainView = false;
+        }
+
+        ledView = ledBuffer.createView(config.getStartingIndex(), config.getEndingIndex());
+
+        // Set initial data and start
+        led.writeData(ledBuffer);
+        led.start();
+
+        // Set default pattern
+        setDefaultCommand(setPattern(defaultPattern, -1).withName("Leds.idle"));
+
+        // Bind triggers
         bindTriggers();
 
         Telemetry.print(getName() + " Subsystem Initialized");
-
-        if (config.getLed() == null) {
-                led = new AddressableLED(config.port);
-                // Length is expensive to set, so only set it once, then just update data
-                ledBuffer = new AddressableLEDBuffer(NUM_LEDS);
-                led.setLength(ledBuffer.getLength());
-                mainView = true;
-            } else {
-                led = config.getLed();
-                ledBuffer = config.buffer;
-            }
-
-            ledView = ledBuffer.createView(config.startingIndex, config.endingIndex);
-
-            // Set the data
-            led.setData(ledBuffer);
-            setPattern(defaultPattern);
-            led.start();
     }
 
-    // TODO: add more patterns and include ones for bps
+    // -------------------------------------------------------------------------
+    // Periodic
+    // -------------------------------------------------------------------------
+
+    @Override
+    public void periodic() {
+        Telemetry.log("Leds/CurrentCommand", getCurrentCommandName());
+        Telemetry.log("Leds/CommandPriority", getCommandPriority());
+
+        if (mainView) {
+            led.writeData(ledBuffer);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Pattern system
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns a command that continuously applies {@code pattern} and tracks {@code priority}.
+     * The command runs while the robot is disabled.
+     *
+     * @param pattern the {@link LEDPattern} to apply to the LED buffer view
+     * @param priority priority level (higher = overrides lower)
+     * @return a command that applies the pattern continuously
+     */
+    public Command setPattern(LEDPattern pattern, int priority) {
+        return run(() -> {
+                    commandPriority = priority;
+                    currentPattern = pattern;
+                    pattern.applyTo(ledView);
+                })
+                .finallyDo(() -> commandPriority = -1)
+                .ignoringDisable(true)
+                .withName("Leds.setPattern");
+    }
+
+    /** Convenience: set pattern at default priority 0. */
+    public Command setPattern(LEDPattern pattern) {
+        return setPattern(pattern, 0);
+    }
+
+    /** Returns a trigger that is active when the current command priority is at or below {@code priority}. */
+    public Trigger checkPriority(int priority) {
+        return new Trigger(() -> commandPriority <= priority);
+    }
+
+    // -------------------------------------------------------------------------
+    // Triggers and bindings
+    // -------------------------------------------------------------------------
 
     void bindTriggers() {
         launchingLed(launchingFuel, 1);
-        redShiftLed(redShfit, 2);
-        blueShiftLed(blueShfit, 2);
+        redShiftLed(redShift, 2);
+        blueShiftLed(blueShift, 2);
         bothHubsActiveLed(bothHubsActive, 2);
-        autonLed(autonomouns, 2);
+        autonLed(autonomous, 2);
     }
 
-    private Trigger redShfit =
+    private Trigger redShift =
             new Trigger(
                             () -> {
                                 double t = DriverStation.getMatchTime();
@@ -118,7 +198,7 @@ public class Leds extends SpectrumLEDs {
                             })
                     .and(Util.teleop);
 
-    private Trigger blueShfit =
+    private Trigger blueShift =
             new Trigger(
                             () -> {
                                 double t = DriverStation.getMatchTime();
@@ -135,13 +215,8 @@ public class Leds extends SpectrumLEDs {
                             })
                     .and(Util.teleop);
 
-    private Trigger autonomouns =
-            new Trigger(
-                    () -> {
-                        return DriverStation.isAutonomous();
-                    });
-
-    // private Trigger bpsLow = new Trigger(() -> {})
+    private Trigger autonomous =
+            new Trigger(() -> DriverStation.isAutonomous());
 
     private Trigger launchingFuel =
             new Trigger(
@@ -155,107 +230,37 @@ public class Leds extends SpectrumLEDs {
                                             == SuperStructure.CurrentSuperState
                                                     .LAUNCH_WITH_SQUEEZE_WITH_NO_DELAY);
 
+    // -------------------------------------------------------------------------
+    // Pattern bindings
+    // -------------------------------------------------------------------------
+
     void redShiftLed(Trigger trigger, int priority) {
-        ledCommand("Leds.Red_Shift", switchCountdown(Color.kRed), priority, trigger);
+        ledCommand("Leds.Red_Shift", LEDPattern.solid(Color.kRed), priority, trigger);
     }
 
     void blueShiftLed(Trigger trigger, int priority) {
-        ledCommand("Leds.Blue_Shift", switchCountdown(Color.kBlue), priority, trigger);
+        ledCommand("Leds.Blue_Shift", LEDPattern.solid(Color.kBlue), priority, trigger);
     }
 
     void bothHubsActiveLed(Trigger trigger, int priority) {
-        ledCommand("Leds.Both_Hubs_Active", gradient(Color.kBlue, Color.kRed), priority, trigger);
+        // Gradient from blue to red across the strip
+        ledCommand("Leds.Both_Hubs_Active",
+                LEDPattern.gradient(LEDPattern.GradientType.kContinuous, Color.kBlue, Color.kRed),
+                priority, trigger);
     }
 
     void autonLed(Trigger trigger, int priority) {
-        ledCommand("Leds.Auton", countdown(() -> 0.0, 20.0), priority, trigger);
+        // Rainbow during autonomous
+        ledCommand("Leds.Auton", LEDPattern.rainbow(), priority, trigger);
     }
 
     void launchingLed(Trigger trigger, int priority) {
-        ledCommand("Leds.Launching", rainbow(0.5), priority, trigger);
+        // Rainbow when launching fuel
+        ledCommand("Leds.Launching", LEDPattern.rainbow(), priority, trigger);
     }
 
-    private Trigger ledCommand(String name, CANdlePattern pattern, int priority, Trigger trigger) {
+    private Trigger ledCommand(String name, LEDPattern pattern, int priority, Trigger trigger) {
         return trigger.and(checkPriority(priority))
                 .whileTrue(setPattern(pattern, priority).withName(name));
     }
-
-    @Override
-    public void periodic() {
-        Telemetry.log("Leds/CurrentCommand", getCurrentCommandName());
-        Telemetry.log("Leds/CommandPriority", getCommandPriority());
-        Telemetry.log("Leds/IsAnimating", isAnimating());
-
-        if (mainView) {
-            led.setData(ledBuffer);
-        }
-    }
-
-    // --------------------------------------------------------------------------------
-    // Simulation
-    // --------------------------------------------------------------------------------
-
-        @SuppressWarnings("unused")
-        private boolean mainView = false;
-
-            // Must be a PWM header, not MXP or DIO
-            if (config.getLed() == null) {
-                led = new AddressableLED(config.port);
-                // Length is expensive to set, so only set it once, then just update data
-                ledBuffer = new AddressableLEDBuffer(NUM_LEDS);
-                led.setLength(ledBuffer.getLength());
-                mainView = true;
-            } else {
-                led = config.getLed();
-                ledBuffer = config.buffer;
-            }
-
-            ledView = ledBuffer.createView(config.startingIndex, config.endingIndex);
-
-            // Set the data
-            led.setData(ledBuffer);
-            setPattern(defaultPattern);
-            led.start();
 }
-
-/*
- *     @Getter protected final AddressableLED led;
-    @Getter protected final AddressableLEDBuffer ledBuffer;
-    @Getter protected final AddressableLEDBufferView ledView;
-    private boolean mainView = false;
-
-    protected final LEDPattern defaultPattern = blink(Color.kOrange, 1);
-
-    @Getter
-    protected Command defaultCommand =
-            setPattern(defaultPattern, -1).withName("LEDs.defaultCommand");
-
-    public final Trigger defaultTrigger = new Trigger(() -> defaultCommand.isScheduled());
-
-    @Getter @Setter private int commandPriority = 0;
-
-    public final Color purple = new Color(130, 103, 185);
-    public final Color white = Color.kWhite;
-
-    public SpectrumLEDs(Config config) {
-        this.config = config;
-
-        // Must be a PWM header, not MXP or DIO
-        if (config.getLed() == null) {
-            led = new AddressableLED(config.port);
-            // Length is expensive to set, so only set it once, then just update data
-            ledBuffer = new AddressableLEDBuffer(config.length);
-            led.setLength(ledBuffer.getLength());
-            mainView = true;
-        } else {
-            led = config.getLed();
-            ledBuffer = config.buffer;
-        }
-
-        ledView = ledBuffer.createView(config.startingIndex, config.endingIndex);
-
-        // Set the data
-        led.setData(ledBuffer);
-        setPattern(defaultPattern);
-        led.start();
- */


### PR DESCRIPTION
## Problem
The `Leds.java` file on the `leds-w-new-state-machine` branch was broken and would not compile:

- Extended `SpectrumLEDs` (CANdle-based, uses CTRE CANdle hardware) while also declaring `AddressableLED` fields (roboRIO PWM port). These are two different hardware interfaces that cannot be mixed this way.
- Had **duplicate initialization blocks**: the constructor ran LED init once in the constructor body, then the same code appeared again as orphaned floating statements (lines 198-218) outside any method.
- Referenced `ledBuffer`, `ledView`, and `mainView` from the old `SpectrumLEDs` parent class, but those fields no longer exist in the current `SpectrumLEDs` (which was rewritten to be CANdle-only).
- Had a large commented-out code block at the bottom (lines 221-260) showing the old `SpectrumLEDs` AddressableLED implementation that was removed.
- Typo: `redShfit` instead of `redShift`.

## Fix
Rewrote `Leds.java` to use the WPILib `AddressableLED` API directly:

- **Extends `SubsystemBase`** directly, no longer extends `SpectrumLEDs` (decoupled from CANdle).
- Uses `AddressableLED` + `AddressableLEDBuffer` + `AddressableLEDBufferView` for roboRIO PWM port LED control.
- Patterns use the WPILib `LEDPattern` API (`solid`, `rainbow`, `gradient`, `breathe`) instead of CANdle animations.
- Uses `writeData()` per the WPILib 2026 API (deprecated `setData` replaced).
- Removed all orphaned code, duplicate init blocks, and dead commented-out code.
- Fixed `redShfit` typo to `redShift`.
- `LedConfig` simplified to a standalone class (no longer extends `CANdleConfig`).
- Supports both standalone (owns the LED hardware) and shared (multi-zone via shared `AddressableLED` + buffer) configurations.
- Default pattern: breathing purple at 2s period (Spectrum purple RGB 130, 103, 185).

## API Reference
- [AddressableLED (WPILib 2026)](https://github.wpilib.org/allwpilib/docs/release/java/edu/wpi/first/wpilibj/AddressableLED.html)
- [LEDPattern (WPILib 2026)](https://github.wpilib.org/allwpilib/docs/release/java/edu/wpi/first/wpilibj/LEDPattern.html)

## Test Plan
- [ ] Compiles with `./gradlew build`
- [ ] Spotless formatting passes (`./gradlew spotlessCheck`)
- [ ] LED strip lights up with breathing purple on robot startup
- [ ] Alliance color patterns trigger correctly during teleop
- [ ] Rainbow pattern triggers when launching fuel
