### PR TITLE
CI on all branches, Gradle caching, and a local verify script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,11 +2,16 @@
 
 name: CI
 
-# Triggers on push to main, and on ANY pull request regardless of target branch.
+# Triggers on push to ANY branch, and on ANY pull request regardless of target branch.
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "**" ]
   pull_request:
+
+# Cancel superseded runs on the same ref so we don't burn CI minutes on stale commits.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -26,6 +31,10 @@ jobs:
       - name: Add repository to git safe directories
         run: git config --global --add safe.directory $GITHUB_WORKSPACE
 
+      # Caches the Gradle dependency and build caches so most runs skip re-downloading.
+      - name: Set up Gradle caching
+        uses: gradle/actions/setup-gradle@v4
+
       # Grant execute permission for gradlew
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
@@ -34,6 +43,18 @@ jobs:
       - name: Check Java formatting (Spotless)
         run: ./gradlew spotlessCheck
 
-      # Runs a single command using the runners shell
-      - name: Compile and run tests on robot code
+      # Compile, run SpotBugs static analysis, and run the JUnit tests.
+      - name: Build, static analysis and tests
         run: ./gradlew build
+
+      # Keep the verification reports so a failed run is debuggable without re-running locally.
+      - name: Upload verification reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: verification-reports
+          path: |
+            build/reports/
+            build/test-results/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,0 +1,4 @@
+# Pin the JDK this project builds with (WPILib 2026 targets Java 17).
+# With sdkman installed, run `sdk env` in this dir (or enable auto-env) to switch.
+# On a fresh machine, `sdk env install` installs it.
+java=17.0.19-tem

--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ This is the working code base for our robots in the 2026 REBUILT FRC Competition
 * **Git Lens:** lets you see who committed changes and more
 * **SpellRight:** Spell Check for VSCode
 
+### Verify Locally
+
+Run the same checks CI runs before you push:
+
+```bash
+scripts/verify.sh        # formatting, static analysis, compile, and tests
+scripts/verify.sh --fix  # auto-format first, then verify
+```
+
 ### Dependencies
 
 * WPILib 2026

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Run the full verification pipeline locally, the same checks CI runs.
+#
+# Usage:
+#   scripts/verify.sh          check only (fails if formatting is off)
+#   scripts/verify.sh --fix    auto-apply formatting first, then verify
+#
+# spotlessCheck -> formatting;  build -> compile + SpotBugs static analysis + JUnit tests.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+if [[ "${1:-}" == "--fix" ]]; then
+    ./gradlew spotlessApply
+fi
+
+./gradlew spotlessCheck build


### PR DESCRIPTION
Closes #114

The robot code is the important, safety-relevant kind, but the pipeline around it was thin. This makes verifying it cheap and frictionless so it actually happens before code is pushed.

## Changes
- **CI runs on all branches.** Pushes to any branch now trigger CI, not just `main` (PRs already ran).
- **Faster CI.** Gradle dependency and build caching, and superseded runs on the same ref are cancelled.
- **Debuggable failures.** SpotBugs and test reports are uploaded as build artifacts, so a red run can be inspected without re-running locally.
- **`scripts/verify.sh`.** One command runs the same checks CI runs (formatting, SpotBugs, compile, tests). `--fix` auto-formats first.
- **`.sdkmanrc`.** Pins JDK 17 (WPILib 2026's target) so `verify.sh` uses the right toolchain locally.

## Verification
`scripts/verify.sh` was run locally under JDK 17: `BUILD SUCCESSFUL`, spotlessCheck + SpotBugs + build all pass.

## Follow-up (not in this PR)
AI-assisted PR review workflow. It needs an API key secret and a team decision, so it's left out for now.