### PR TITLE
refactor: rewrite IntakeExtension to follow DyeRotor container pattern

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -49,6 +49,8 @@ import frc.robot.subsystems.hood.Hood;
 import frc.robot.subsystems.hood.Hood.HoodConfig;
 import frc.robot.subsystems.intakeExtension.IntakeExtension;
 import frc.robot.subsystems.intakeExtension.IntakeExtension.IntakeExtensionConfig;
+import frc.robot.subsystems.intakeExtension.IntakeExtension.Left.LeftConfig;
+import frc.robot.subsystems.intakeExtension.IntakeExtension.Right.RightConfig;
 import frc.robot.subsystems.launcher.Launcher;
 import frc.robot.subsystems.launcher.Launcher.LauncherConfig;
 import frc.robot.subsystems.launcher.LauncherTower;
@@ -94,7 +96,10 @@ public class Robot extends SpectrumRobot {
         public final IntakeRollerConfig intakeRoller = new IntakeRollerConfig();
         public final IntakeKickerConfig intakeKicker = new IntakeKickerConfig();
         public final FuelIntakeConfig fuelIntake = new FuelIntakeConfig(intakeRoller, intakeKicker);
-        public final IntakeExtensionConfig intakeExtension = new IntakeExtensionConfig();
+        public final LeftConfig intakeExtensionLeft = new LeftConfig();
+        public final RightConfig intakeExtensionRight = new RightConfig(intakeExtensionLeft);
+        public final IntakeExtensionConfig intakeExtension =
+                new IntakeExtensionConfig(intakeExtensionLeft, intakeExtensionRight);
         public final RotorConfig rotor = new RotorConfig();
         public final FeederConfig feeder = new FeederConfig();
         public final DyeRotorConfig dyeRotor = new DyeRotorConfig(rotor, feeder);

--- a/src/main/java/frc/robot/configs/AM2026.java
+++ b/src/main/java/frc/robot/configs/AM2026.java
@@ -4,7 +4,9 @@ import frc.robot.Robot.Config;
 
 public class AM2026 extends Config {
 
-    // Alpha Machine
+    /**
+     * Configures the Alpha Machine robot, including swerve encoder offsets and mechanism attachment states.
+     */
     public AM2026() {
         super();
         swerve.configEncoderOffsets(0.289551, 0.394043, -0.203857, -0.039307);

--- a/src/main/java/frc/robot/configs/AM2026.java
+++ b/src/main/java/frc/robot/configs/AM2026.java
@@ -14,7 +14,8 @@ public class AM2026 extends Config {
         operator.setAttached(true);
         intakeRoller.setAttached(false);
         intakeKicker.setAttached(false);
-        intakeExtension.setAttached(false);
+        intakeExtensionLeft.setAttached(false);
+        intakeExtensionRight.setAttached(false);
         // indexerTower.setAttached(false);
         launcher.setAttached(false);
     }

--- a/src/main/java/frc/robot/configs/AM2026.java
+++ b/src/main/java/frc/robot/configs/AM2026.java
@@ -5,7 +5,8 @@ import frc.robot.Robot.Config;
 public class AM2026 extends Config {
 
     /**
-     * Configures the Alpha Machine robot, including swerve encoder offsets and mechanism attachment states.
+     * Configures the Alpha Machine robot, including swerve encoder offsets and mechanism attachment
+     * states.
      */
     public AM2026() {
         super();

--- a/src/main/java/frc/robot/configs/FM2026.java
+++ b/src/main/java/frc/robot/configs/FM2026.java
@@ -5,7 +5,8 @@ import frc.robot.Robot.Config;
 public class FM2026 extends Config {
 
     /**
-     * Initializes the Final Machine configuration, including swerve encoder offsets and attached mechanisms.
+     * Initializes the Final Machine configuration, including swerve encoder offsets and attached
+     * mechanisms.
      */
     public FM2026() {
         super();

--- a/src/main/java/frc/robot/configs/FM2026.java
+++ b/src/main/java/frc/robot/configs/FM2026.java
@@ -4,7 +4,9 @@ import frc.robot.Robot.Config;
 
 public class FM2026 extends Config {
 
-    // Final Machine
+    /**
+     * Initializes the Final Machine configuration, including swerve encoder offsets and attached mechanisms.
+     */
     public FM2026() {
         super();
         swerve.configEncoderOffsets(-0.163818359375, 0.24902, 0.2724609375, -0.31005859375);

--- a/src/main/java/frc/robot/configs/FM2026.java
+++ b/src/main/java/frc/robot/configs/FM2026.java
@@ -14,7 +14,8 @@ public class FM2026 extends Config {
         operator.setAttached(true);
         intakeRoller.setAttached(true);
         intakeKicker.setAttached(true);
-        intakeExtension.setAttached(true);
+        intakeExtensionLeft.setAttached(true);
+        intakeExtensionRight.setAttached(true);
         launcher.setAttached(true);
         // indexerTower.setAttached(true);
         rotor.setAttached(true);

--- a/src/main/java/frc/robot/configs/OM2026.java
+++ b/src/main/java/frc/robot/configs/OM2026.java
@@ -13,7 +13,8 @@ public class OM2026 extends Config {
         operator.setAttached(true);
         intakeRoller.setAttached(true);
         intakeKicker.setAttached(true);
-        intakeExtension.setAttached(true);
+        intakeExtensionLeft.setAttached(true);
+        intakeExtensionRight.setAttached(true);
         launcher.setAttached(true);
         rotor.setAttached(true);
         feeder.setAttached(true);

--- a/src/main/java/frc/robot/configs/OM2026.java
+++ b/src/main/java/frc/robot/configs/OM2026.java
@@ -3,6 +3,9 @@ package frc.robot.configs;
 import frc.robot.Robot.Config;
 
 public class OM2026 extends Config {
+    /**
+     * Initializes the 2026 robot configuration with attached subsystems and swerve encoder offsets.
+     */
     public OM2026() {
         super();
 

--- a/src/main/java/frc/robot/configs/PHOTON2026.java
+++ b/src/main/java/frc/robot/configs/PHOTON2026.java
@@ -4,7 +4,10 @@ import frc.robot.Robot.Config;
 
 public class PHOTON2026 extends Config {
 
-    // Photon Machine
+    /**
+     * Initializes the Photon Machine robot configuration, including swerve encoder offsets
+     * and attached mechanisms.
+     */
     public PHOTON2026() {
         super();
         swerve.configEncoderOffsets(0.127197265625, -0.260009765625, 0.1171875, -0.3427734375);

--- a/src/main/java/frc/robot/configs/PHOTON2026.java
+++ b/src/main/java/frc/robot/configs/PHOTON2026.java
@@ -14,7 +14,8 @@ public class PHOTON2026 extends Config {
         operator.setAttached(true);
         intakeRoller.setAttached(true);
         intakeKicker.setAttached(true);
-        intakeExtension.setAttached(true);
+        intakeExtensionLeft.setAttached(true);
+        intakeExtensionRight.setAttached(true);
         launcher.setAttached(true);
         // indexerTower.setAttached(true);
         // indexerBed.setAttached(true);

--- a/src/main/java/frc/robot/configs/PHOTON2026.java
+++ b/src/main/java/frc/robot/configs/PHOTON2026.java
@@ -5,8 +5,8 @@ import frc.robot.Robot.Config;
 public class PHOTON2026 extends Config {
 
     /**
-     * Initializes the Photon Machine robot configuration, including swerve encoder offsets
-     * and attached mechanisms.
+     * Initializes the Photon Machine robot configuration, including swerve encoder offsets and
+     * attached mechanisms.
      */
     public PHOTON2026() {
         super();

--- a/src/main/java/frc/robot/configs/PM2026.java
+++ b/src/main/java/frc/robot/configs/PM2026.java
@@ -4,7 +4,9 @@ import frc.robot.Robot.Config;
 
 public class PM2026 extends Config {
 
-    // Final Machine
+    /**
+     * Initializes the final machine configuration, including swerve encoder offsets and attached mechanisms.
+     */
     public PM2026() {
         super();
         swerve.configEncoderOffsets(

--- a/src/main/java/frc/robot/configs/PM2026.java
+++ b/src/main/java/frc/robot/configs/PM2026.java
@@ -5,7 +5,7 @@ import frc.robot.Robot.Config;
 public class PM2026 extends Config {
 
     /**
-     * Initializes the final machine configuration, including swerve encoder offsets and attached
+     * Initializes the Practice Machine configuration, including swerve encoder offsets and attached
      * mechanisms.
      */
     public PM2026() {

--- a/src/main/java/frc/robot/configs/PM2026.java
+++ b/src/main/java/frc/robot/configs/PM2026.java
@@ -5,7 +5,8 @@ import frc.robot.Robot.Config;
 public class PM2026 extends Config {
 
     /**
-     * Initializes the final machine configuration, including swerve encoder offsets and attached mechanisms.
+     * Initializes the final machine configuration, including swerve encoder offsets and attached
+     * mechanisms.
      */
     public PM2026() {
         super();

--- a/src/main/java/frc/robot/configs/PM2026.java
+++ b/src/main/java/frc/robot/configs/PM2026.java
@@ -15,7 +15,8 @@ public class PM2026 extends Config {
         operator.setAttached(true);
         intakeRoller.setAttached(true);
         intakeKicker.setAttached(true);
-        intakeExtension.setAttached(true);
+        intakeExtensionLeft.setAttached(true);
+        intakeExtensionRight.setAttached(true);
         launcher.setAttached(true);
         // indexerTower.setAttached(true);
         // indexerBed.setAttached(true);

--- a/src/main/java/frc/robot/configs/XM2026.java
+++ b/src/main/java/frc/robot/configs/XM2026.java
@@ -18,7 +18,8 @@ public class XM2026 extends Config {
         operator.setAttached(true);
         intakeRoller.setAttached(true);
         intakeKicker.setAttached(true);
-        intakeExtension.setAttached(false);
+        intakeExtensionLeft.setAttached(false);
+        intakeExtensionRight.setAttached(false);
         launcher.setAttached(true);
         // indexerTower.setAttached(true);
         // indexerBed.setAttached(true);

--- a/src/main/java/frc/robot/configs/XM2026.java
+++ b/src/main/java/frc/robot/configs/XM2026.java
@@ -4,7 +4,9 @@ import frc.robot.Robot.Config;
 
 public class XM2026 extends Config {
 
-    // Experimental Machine
+    /**
+     * Configures the Experimental Machine robot and its attached mechanisms.
+     */
     public XM2026() {
         super();
         swerve.configEncoderOffsets(

--- a/src/main/java/frc/robot/configs/XM2026.java
+++ b/src/main/java/frc/robot/configs/XM2026.java
@@ -4,9 +4,7 @@ import frc.robot.Robot.Config;
 
 public class XM2026 extends Config {
 
-    /**
-     * Configures the Experimental Machine robot and its attached mechanisms.
-     */
+    /** Configures the Experimental Machine robot and its attached mechanisms. */
     public XM2026() {
         super();
         swerve.configEncoderOffsets(

--- a/src/main/java/frc/robot/subsystems/dyeRotor/DyeRotor.java
+++ b/src/main/java/frc/robot/subsystems/dyeRotor/DyeRotor.java
@@ -258,8 +258,6 @@ public class DyeRotor implements Subsystem {
         Telemetry.print("Dye Rotor Subsystem Initialized");
     }
 
-
-
     @Override
     public void periodic() {
         systemState = handleStateTransition();

--- a/src/main/java/frc/robot/subsystems/dyeRotor/DyeRotor.java
+++ b/src/main/java/frc/robot/subsystems/dyeRotor/DyeRotor.java
@@ -249,6 +249,11 @@ public class DyeRotor implements Subsystem {
     @Getter private final Feeder feeder;
     @Getter private final DyeRotorConfig config;
 
+    /**
+     * Creates and registers the dye rotor subsystem with the specified configuration.
+     *
+     * @param config configuration for the rotor and feeder mechanisms
+     */
     public DyeRotor(DyeRotorConfig config) {
         this.config = config;
         this.rotor = new Rotor(config.getRotorConfig());
@@ -258,6 +263,10 @@ public class DyeRotor implements Subsystem {
         Telemetry.print("Dye Rotor Subsystem Initialized");
     }
 
+    /**
+     * Updates the internal state, applies the corresponding rotor and feeder commands,
+     * and records the requested and active states in telemetry.
+     */
     @Override
     public void periodic() {
         systemState = handleStateTransition();

--- a/src/main/java/frc/robot/subsystems/dyeRotor/DyeRotor.java
+++ b/src/main/java/frc/robot/subsystems/dyeRotor/DyeRotor.java
@@ -264,8 +264,8 @@ public class DyeRotor implements Subsystem {
     }
 
     /**
-     * Updates the internal state, applies the corresponding rotor and feeder commands,
-     * and records the requested and active states in telemetry.
+     * Updates the internal state, applies the corresponding rotor and feeder commands, and records
+     * the requested and active states in telemetry.
      */
     @Override
     public void periodic() {

--- a/src/main/java/frc/robot/subsystems/hood/Hood.java
+++ b/src/main/java/frc/robot/subsystems/hood/Hood.java
@@ -16,7 +16,7 @@ import lombok.Setter;
 public class Hood extends Mechanism {
 
     public static class HoodConfig extends Config {
- 
+
         @Getter private final double initPosition = 0.0;
 
         /* 34.5 deg of travel */

--- a/src/main/java/frc/robot/subsystems/intakeExtension/IntakeExtension.java
+++ b/src/main/java/frc/robot/subsystems/intakeExtension/IntakeExtension.java
@@ -19,26 +19,58 @@ import frc.spectrumLib.sim.LinearSim;
 import frc.spectrumLib.telemetry.Telemetry;
 import lombok.Getter;
 
-/**
- * The Intake Extension subsystem. Extends and retracts the fuel intake.
- *
- * <p>The deploy is a rack-and-pinion driven by two independent motors: a left axis (CAN id 4) and a
- * right axis (CAN id 5). Each side runs its own closed-loop position control rather than one
- * following the other, so a side that skips teeth on the rack can be driven on its own to resync.
- *
- * <p>Normal deploy/retract states command both axes to the same setpoint. The {@code RESYNC} state
- * re-establishes truth by driving each side independently into the fully-extended hard stop (using
- * a soft-limit-bypassing voltage), detecting the stall, and re-zeroing that side's encoder at
- * {@code maxRotations}. This recovers from a tooth skip, which otherwise leaves the motor encoder
- * reading a position the rack is no longer at.
- *
- * <p>This is a container for two independent {@link Mechanism}s rather than a {@code Mechanism}
- * itself, so it implements {@link Subsystem} and registers directly. Without that registration the
- * scheduler would never call {@link #periodic()} and the state machine would never run.
- */
 public class IntakeExtension implements Subsystem {
 
-    public static class Left extends Mechanism {
+    public abstract static class IntakeExtensionAxis extends Mechanism {
+
+        public IntakeExtensionAxis(Config config) {
+            super(config);
+        }
+
+        public void goToRotations(double rotations) {
+            setMMPosition(() -> rotations);
+        }
+
+        public void goToRotationsSlow(
+                double rotations, double cruiseVelocity, double acceleration, double jerk) {
+            setDynMMPositionVoltage(
+                    () -> rotations, () -> cruiseVelocity, () -> acceleration, () -> jerk);
+        }
+
+        public void driveHomingVoltage(double volts) {
+            setVoltageOutputNoSoftLimit(() -> volts);
+        }
+
+        public void setInitialPosition(double rotations) {
+            if (isAttached()) {
+                motor.setPosition(rotations);
+            }
+        }
+
+        public void zeroAtMax() {
+            setMotorPosition(() -> config.getMaxRotations());
+        }
+
+        @Override
+        public void stop() {
+            super.stop();
+        }
+
+        @Override
+        public void periodic() {
+            logBatteryUsage();
+            String prefix = getName() + "/";
+            Telemetry.log(prefix + "CurrentCommand", getCurrentCommandName());
+            Telemetry.log(prefix + "Voltage", getVoltage(), "volts");
+            Telemetry.log(prefix + "StatorCurrent", getStatorCurrent(), "amps");
+            Telemetry.log(prefix + "SupplyCurrent", getSupplyCurrent(), "amps");
+            Telemetry.log(prefix + "Position", getPositionRotations(), "rotations");
+            Telemetry.log(prefix + "RPM", getVelocityRPM(), "RPM");
+            Telemetry.log(prefix + "Temp", getTemp(), "deg_C");
+        }
+    }
+
+    public static class Left extends IntakeExtensionAxis {
 
         public static class LeftConfig extends Config {
 
@@ -124,46 +156,6 @@ public class IntakeExtension implements Subsystem {
             Telemetry.print(getName() + " Subsystem Initialized");
         }
 
-        public void goToRotations(double rotations) {
-            setMMPosition(() -> rotations);
-        }
-
-        public void goToRotationsSlow(
-                double rotations, double cruiseVelocity, double acceleration, double jerk) {
-            setDynMMPositionVoltage(
-                    () -> rotations, () -> cruiseVelocity, () -> acceleration, () -> jerk);
-        }
-
-        public void driveHomingVoltage(double volts) {
-            setVoltageOutputNoSoftLimit(() -> volts);
-        }
-
-        public void setInitialPosition(double rotations) {
-            if (isAttached()) {
-                motor.setPosition(rotations);
-            }
-        }
-
-        public void zeroAtMax() {
-            setMotorPosition(() -> config.getMaxRotations());
-        }
-
-        public void stopAxis() {
-            stop();
-        }
-
-        @Override
-        public void periodic() {
-            logBatteryUsage();
-            Telemetry.log("IntakeExtensionLeft/CurrentCommand", getCurrentCommandName());
-            Telemetry.log("IntakeExtensionLeft/Voltage", getVoltage(), "volts");
-            Telemetry.log("IntakeExtensionLeft/StatorCurrent", getStatorCurrent(), "amps");
-            Telemetry.log("IntakeExtensionLeft/SupplyCurrent", getSupplyCurrent(), "amps");
-            Telemetry.log("IntakeExtensionLeft/Position", getPositionRotations(), "rotations");
-            Telemetry.log("IntakeExtensionLeft/RPM", getVelocityRPM(), "RPM");
-            Telemetry.log("IntakeExtensionLeft/Temp", getTemp(), "deg_C");
-        }
-
         public void simulationInit() {
             if (isAttached()) {
                 sim = new IntakeExtensionSim(RobotSim.leftView, motor.getSimState());
@@ -191,9 +183,16 @@ public class IntakeExtension implements Subsystem {
         }
     }
 
-    public static class Right extends Mechanism {
+    public static class Right extends IntakeExtensionAxis {
 
         public static class RightConfig extends Config {
+
+            @Getter private final double homingStallRPM;
+            @Getter private final double homingMinTimeSecs;
+            @Getter private final double homingStallDebounceSecs;
+            @Getter private final double homingTimeoutSecs;
+            @Getter private final double homingVoltage;
+
             public RightConfig(LeftConfig left) {
                 super("IntakeExtensionRight", 5, Rio.CANIVORE);
                 setAttached(left.isAttached());
@@ -220,6 +219,12 @@ public class IntakeExtension implements Subsystem {
                 configReverseSoftLimit(left.getMinRotations(), true);
                 configNeutralBrakeMode(false);
                 configCounterClockwise_Positive();
+
+                this.homingStallRPM = left.getHomingStallRPM();
+                this.homingMinTimeSecs = left.getHomingMinTimeSecs();
+                this.homingStallDebounceSecs = left.getHomingStallDebounceSecs();
+                this.homingTimeoutSecs = left.getHomingTimeoutSecs();
+                this.homingVoltage = left.getHomingVoltage();
             }
         }
 
@@ -229,46 +234,6 @@ public class IntakeExtension implements Subsystem {
             super(config);
             this.config = config;
             Telemetry.print(getName() + " Subsystem Initialized");
-        }
-
-        public void goToRotations(double rotations) {
-            setMMPosition(() -> rotations);
-        }
-
-        public void goToRotationsSlow(
-                double rotations, double cruiseVelocity, double acceleration, double jerk) {
-            setDynMMPositionVoltage(
-                    () -> rotations, () -> cruiseVelocity, () -> acceleration, () -> jerk);
-        }
-
-        public void driveHomingVoltage(double volts) {
-            setVoltageOutputNoSoftLimit(() -> volts);
-        }
-
-        public void setInitialPosition(double rotations) {
-            if (isAttached()) {
-                motor.setPosition(rotations);
-            }
-        }
-
-        public void zeroAtMax() {
-            setMotorPosition(() -> config.getMaxRotations());
-        }
-
-        public void stopAxis() {
-            stop();
-        }
-
-        @Override
-        public void periodic() {
-            logBatteryUsage();
-            Telemetry.log("IntakeExtensionRight/CurrentCommand", getCurrentCommandName());
-            Telemetry.log("IntakeExtensionRight/Voltage", getVoltage(), "volts");
-            Telemetry.log("IntakeExtensionRight/StatorCurrent", getStatorCurrent(), "amps");
-            Telemetry.log("IntakeExtensionRight/SupplyCurrent", getSupplyCurrent(), "amps");
-            Telemetry.log("IntakeExtensionRight/Position", getPositionRotations(), "rotations");
-            Telemetry.log("IntakeExtensionRight/RPM", getVelocityRPM(), "RPM");
-            Telemetry.log("IntakeExtensionRight/Temp", getTemp(), "deg_C");
         }
     }
 
@@ -345,8 +310,8 @@ public class IntakeExtension implements Subsystem {
                 applyHoming();
                 break;
             case STOPPED:
-                left.stopAxis();
-                right.stopAxis();
+                left.stop();
+                right.stop();
                 return;
         }
     }
@@ -391,17 +356,21 @@ public class IntakeExtension implements Subsystem {
         double homingVoltage = config.getLeftConfig().getHomingVoltage();
         boolean timedOut = homingTimer.get() >= homingTimeout;
 
-        if (!leftHomed) {
-            if (detectLeftStall() || timedOut) {
-                if (timedOut) Telemetry.print("IntakeExtension: LEFT resync timed out");
-                left.zeroAtMax();
-                left.stopAxis();
-                leftHomed = true;
+        if (left.isAttached()) {
+            if (!leftHomed) {
+                if (detectLeftStall() || timedOut) {
+                    if (timedOut) Telemetry.print("IntakeExtension: LEFT resync timed out");
+                    left.zeroAtMax();
+                    left.stop();
+                    leftHomed = true;
+                } else {
+                    left.driveHomingVoltage(homingVoltage);
+                }
             } else {
-                left.driveHomingVoltage(homingVoltage);
+                left.stop();
             }
         } else {
-            left.stopAxis();
+            leftHomed = true;
         }
 
         if (right.isAttached()) {
@@ -409,13 +378,13 @@ public class IntakeExtension implements Subsystem {
                 if (detectRightStall() || timedOut) {
                     if (timedOut) Telemetry.print("IntakeExtension: RIGHT resync timed out");
                     right.zeroAtMax();
-                    right.stopAxis();
+                    right.stop();
                     rightHomed = true;
                 } else {
                     right.driveHomingVoltage(homingVoltage);
                 }
             } else {
-                right.stopAxis();
+                right.stop();
             }
         } else {
             rightHomed = true;
@@ -424,29 +393,27 @@ public class IntakeExtension implements Subsystem {
 
     private boolean detectLeftStall() {
         double now = homingTimer.get();
-        double stallRPM = config.getLeftConfig().getHomingStallRPM();
-        if (Math.abs(left.getVelocityRPM()) >= stallRPM) {
+        LeftConfig cfg = config.getLeftConfig();
+        if (Math.abs(left.getVelocityRPM()) >= cfg.getHomingStallRPM()) {
             leftLastMoving = now;
         }
-        return isStalled(now, leftLastMoving);
+        return isStalled(now, leftLastMoving, cfg.getHomingMinTimeSecs(), cfg.getHomingStallDebounceSecs());
     }
 
     private boolean detectRightStall() {
         double now = homingTimer.get();
-        double stallRPM = config.getLeftConfig().getHomingStallRPM();
-        if (Math.abs(right.getVelocityRPM()) >= stallRPM) {
+        RightConfig cfg = config.getRightConfig();
+        if (Math.abs(right.getVelocityRPM()) >= cfg.getHomingStallRPM()) {
             rightLastMoving = now;
         }
-        return isStalled(now, rightLastMoving);
+        return isStalled(now, rightLastMoving, cfg.getHomingMinTimeSecs(), cfg.getHomingStallDebounceSecs());
     }
 
-    private boolean isStalled(double now, double lastMoving) {
-        double minTime = config.getLeftConfig().getHomingMinTimeSecs();
-        double debounce = config.getLeftConfig().getHomingStallDebounceSecs();
-        if (now < minTime) {
+    private boolean isStalled(double now, double lastMoving, double minTimeSecs, double stallDebounceSecs) {
+        if (now < minTimeSecs) {
             return false;
         }
-        return (now - lastMoving) >= debounce;
+        return (now - lastMoving) >= stallDebounceSecs;
     }
 
     public boolean isResyncComplete() {

--- a/src/main/java/frc/robot/subsystems/intakeExtension/IntakeExtension.java
+++ b/src/main/java/frc/robot/subsystems/intakeExtension/IntakeExtension.java
@@ -21,56 +21,7 @@ import lombok.Getter;
 
 public class IntakeExtension implements Subsystem {
 
-    public abstract static class IntakeExtensionAxis extends Mechanism {
-
-        public IntakeExtensionAxis(Config config) {
-            super(config);
-        }
-
-        public void goToRotations(double rotations) {
-            setMMPosition(() -> rotations);
-        }
-
-        public void goToRotationsSlow(
-                double rotations, double cruiseVelocity, double acceleration, double jerk) {
-            setDynMMPositionVoltage(
-                    () -> rotations, () -> cruiseVelocity, () -> acceleration, () -> jerk);
-        }
-
-        public void driveHomingVoltage(double volts) {
-            setVoltageOutputNoSoftLimit(() -> volts);
-        }
-
-        public void setInitialPosition(double rotations) {
-            if (isAttached()) {
-                motor.setPosition(rotations);
-            }
-        }
-
-        public void zeroAtMax() {
-            setMotorPosition(() -> config.getMaxRotations());
-        }
-
-        @Override
-        public void stop() {
-            super.stop();
-        }
-
-        @Override
-        public void periodic() {
-            logBatteryUsage();
-            String prefix = getName() + "/";
-            Telemetry.log(prefix + "CurrentCommand", getCurrentCommandName());
-            Telemetry.log(prefix + "Voltage", getVoltage(), "volts");
-            Telemetry.log(prefix + "StatorCurrent", getStatorCurrent(), "amps");
-            Telemetry.log(prefix + "SupplyCurrent", getSupplyCurrent(), "amps");
-            Telemetry.log(prefix + "Position", getPositionRotations(), "rotations");
-            Telemetry.log(prefix + "RPM", getVelocityRPM(), "RPM");
-            Telemetry.log(prefix + "Temp", getTemp(), "deg_C");
-        }
-    }
-
-    public static class Left extends IntakeExtensionAxis {
+    public static class Left extends Mechanism {
 
         public static class LeftConfig extends Config {
 
@@ -156,6 +107,48 @@ public class IntakeExtension implements Subsystem {
             Telemetry.print(getName() + " Subsystem Initialized");
         }
 
+        @Override
+        public void stop() {
+            super.stop();
+        }
+
+        @Override
+        public void periodic() {
+            logBatteryUsage();
+            String prefix = getName() + "/";
+            Telemetry.log(prefix + "CurrentCommand", getCurrentCommandName());
+            Telemetry.log(prefix + "Voltage", getVoltage(), "volts");
+            Telemetry.log(prefix + "StatorCurrent", getStatorCurrent(), "amps");
+            Telemetry.log(prefix + "SupplyCurrent", getSupplyCurrent(), "amps");
+            Telemetry.log(prefix + "Position", getPositionRotations(), "rotations");
+            Telemetry.log(prefix + "RPM", getVelocityRPM(), "RPM");
+            Telemetry.log(prefix + "Temp", getTemp(), "deg_C");
+        }
+
+        public void goToRotations(double rotations) {
+            setMMPosition(() -> rotations);
+        }
+
+        public void goToRotationsSlow(
+                double rotations, double cruiseVelocity, double acceleration, double jerk) {
+            setDynMMPositionVoltage(
+                    () -> rotations, () -> cruiseVelocity, () -> acceleration, () -> jerk);
+        }
+
+        public void driveHomingVoltage(double volts) {
+            setVoltageOutputNoSoftLimit(() -> volts);
+        }
+
+        public void setInitialPosition(double rotations) {
+            if (isAttached()) {
+                motor.setPosition(rotations);
+            }
+        }
+
+        public void zeroAtMax() {
+            setMotorPosition(() -> config.getMaxRotations());
+        }
+
         public void simulationInit() {
             if (isAttached()) {
                 sim = new IntakeExtensionSim(RobotSim.leftView, motor.getSimState());
@@ -183,7 +176,7 @@ public class IntakeExtension implements Subsystem {
         }
     }
 
-    public static class Right extends IntakeExtensionAxis {
+    public static class Right extends Mechanism {
 
         public static class RightConfig extends Config {
 
@@ -234,6 +227,48 @@ public class IntakeExtension implements Subsystem {
             super(config);
             this.config = config;
             Telemetry.print(getName() + " Subsystem Initialized");
+        }
+
+        @Override
+        public void stop() {
+            super.stop();
+        }
+
+        @Override
+        public void periodic() {
+            logBatteryUsage();
+            String prefix = getName() + "/";
+            Telemetry.log(prefix + "CurrentCommand", getCurrentCommandName());
+            Telemetry.log(prefix + "Voltage", getVoltage(), "volts");
+            Telemetry.log(prefix + "StatorCurrent", getStatorCurrent(), "amps");
+            Telemetry.log(prefix + "SupplyCurrent", getSupplyCurrent(), "amps");
+            Telemetry.log(prefix + "Position", getPositionRotations(), "rotations");
+            Telemetry.log(prefix + "RPM", getVelocityRPM(), "RPM");
+            Telemetry.log(prefix + "Temp", getTemp(), "deg_C");
+        }
+
+        public void goToRotations(double rotations) {
+            setMMPosition(() -> rotations);
+        }
+
+        public void goToRotationsSlow(
+                double rotations, double cruiseVelocity, double acceleration, double jerk) {
+            setDynMMPositionVoltage(
+                    () -> rotations, () -> cruiseVelocity, () -> acceleration, () -> jerk);
+        }
+
+        public void driveHomingVoltage(double volts) {
+            setVoltageOutputNoSoftLimit(() -> volts);
+        }
+
+        public void setInitialPosition(double rotations) {
+            if (isAttached()) {
+                motor.setPosition(rotations);
+            }
+        }
+
+        public void zeroAtMax() {
+            setMotorPosition(() -> config.getMaxRotations());
         }
     }
 

--- a/src/main/java/frc/robot/subsystems/intakeExtension/IntakeExtension.java
+++ b/src/main/java/frc/robot/subsystems/intakeExtension/IntakeExtension.java
@@ -73,6 +73,10 @@ public class IntakeExtension implements Subsystem {
             @Getter private final double lineWidth = 20;
             @Getter private final double maxExtensionHeight = 40;
 
+            /**
+             * Initializes the left intake extension motor configuration, including motion control,
+             * current limits, soft limits, braking, gearing, and positive rotation direction.
+             */
             public LeftConfig() {
                 super("IntakeExtensionLeft", 4, Rio.CANIVORE);
                 configMinMaxRotations(minRotations, maxRotations);
@@ -99,6 +103,11 @@ public class IntakeExtension implements Subsystem {
         @Getter private final LeftConfig config;
         @Getter private IntakeExtensionSim sim;
 
+        /**
+         * Creates and initializes the left intake extension axis.
+         *
+         * @param config configuration for the left intake extension axis
+         */
         public Left(LeftConfig config) {
             super(config);
             this.config = config;
@@ -125,7 +134,14 @@ public class IntakeExtension implements Subsystem {
             setMMPosition(() -> rotations);
         }
 
-        /** Slow (dynamic Motion Magic voltage) move to a rotation target. */
+        /**
+         * Moves the axis to a rotation target using a dynamic motion profile.
+         *
+         * @param rotations       the target position in rotations
+         * @param cruiseVelocity  the motion profile's cruise velocity
+         * @param acceleration    the motion profile's acceleration
+         * @param jerk            the motion profile's jerk
+         */
         public void goToRotationsSlow(
                 double rotations, double cruiseVelocity, double acceleration, double jerk) {
             setDynMMPositionVoltage(
@@ -154,6 +170,9 @@ public class IntakeExtension implements Subsystem {
             stop();
         }
 
+        /**
+         * Initializes the left extension axis simulation when the mechanism is attached.
+         */
         public void simulationInit() {
             if (isAttached()) {
                 sim = new IntakeExtensionSim(RobotSim.leftView, motor.getSimState());
@@ -161,6 +180,12 @@ public class IntakeExtension implements Subsystem {
         }
 
         class IntakeExtensionSim extends LinearSim {
+            /**
+             * Initializes the intake extension simulation model.
+             *
+             * @param mech the mechanism visualization to bind to the simulation
+             * @param motorSim the motor simulation state driving the model
+             */
             public IntakeExtensionSim(Mechanism2d mech, TalonFXSimState motorSim) {
                 super(
                         new LinearConfig(
@@ -191,6 +216,11 @@ public class IntakeExtension implements Subsystem {
             @Getter private final double homingTimeoutSecs;
             @Getter private final double homingVoltage;
 
+            /**
+             * Creates a right-axis configuration using the left-axis control and homing settings.
+             *
+             * @param left the left-axis configuration supplying shared settings
+             */
             public RightConfig(LeftConfig left) {
                 super("IntakeExtensionRight", 5, Rio.CANIVORE);
                 setAttached(left.isAttached());
@@ -287,6 +317,12 @@ public class IntakeExtension implements Subsystem {
         @Getter private final LeftConfig leftConfig;
         @Getter private final RightConfig rightConfig;
 
+        /**
+         * Creates an intake extension configuration from the configurations for both axes.
+         *
+         * @param leftConfig  the left-axis configuration
+         * @param rightConfig the right-axis configuration
+         */
         public IntakeExtensionConfig(LeftConfig leftConfig, RightConfig rightConfig) {
             this.leftConfig = leftConfig;
             this.rightConfig = rightConfig;
@@ -340,6 +376,9 @@ public class IntakeExtension implements Subsystem {
         };
     }
 
+    /**
+     * Applies the outputs associated with the current system state.
+     */
     private void applyStates() {
         switch (systemState) {
             case FULL_EXTEND:
@@ -361,6 +400,12 @@ public class IntakeExtension implements Subsystem {
         }
     }
 
+    /**
+     * Commands both intake extension axes to the specified extension percentage.
+     *
+     * @param percent the target extension percentage
+     * @param slow    whether to use the slow motion profile
+     */
     private void commandBoth(double percent, boolean slow) {
         final double rotations = left.percentToRotations(() -> percent);
         if (slow) {
@@ -388,6 +433,10 @@ public class IntakeExtension implements Subsystem {
     private double leftLastMoving = 0;
     private double rightLastMoving = 0;
 
+    /**
+     * Drives both extension axes through the homing process and marks each axis complete when
+     * a stall is detected, the homing timeout is reached, or the axis is unattached.
+     */
     private void applyHoming() {
         if (previousSystemState != SystemState.HOMING) {
             homingTimer.restart();
@@ -436,6 +485,12 @@ public class IntakeExtension implements Subsystem {
         }
     }
 
+    /**
+     * Determines whether the left extension is stalled according to its homing thresholds.
+     *
+     * @return {@code true} if the minimum homing time has elapsed and the axis has remained below
+     *         the stall velocity threshold for the debounce period, {@code false} otherwise
+     */
     private boolean detectLeftStall() {
         double now = homingTimer.get();
         LeftConfig cfg = config.getLeftConfig();
@@ -446,6 +501,12 @@ public class IntakeExtension implements Subsystem {
                 now, leftLastMoving, cfg.getHomingMinTimeSecs(), cfg.getHomingStallDebounceSecs());
     }
 
+    /**
+     * Determines whether the right extension axis has stalled during homing.
+     *
+     * @return {@code true} if the axis has remained below the stall velocity threshold
+     *         for the required debounce period after the minimum homing time; {@code false} otherwise
+     */
     private boolean detectRightStall() {
         double now = homingTimer.get();
         RightConfig cfg = config.getRightConfig();
@@ -456,6 +517,15 @@ public class IntakeExtension implements Subsystem {
                 now, rightLastMoving, cfg.getHomingMinTimeSecs(), cfg.getHomingStallDebounceSecs());
     }
 
+    /**
+     * Determines whether motion has remained below the stall threshold for the required duration.
+     *
+     * @param now               the current homing time in seconds
+     * @param lastMoving        the most recent time motion was detected in seconds
+     * @param minTimeSecs       the minimum elapsed time before stall detection begins
+     * @param stallDebounceSecs the required duration without motion before reporting a stall
+     * @return                  {@code true} if the minimum time has elapsed and the debounce duration has passed, {@code false} otherwise
+     */
     private boolean isStalled(
             double now, double lastMoving, double minTimeSecs, double stallDebounceSecs) {
         if (now < minTimeSecs) {
@@ -464,10 +534,20 @@ public class IntakeExtension implements Subsystem {
         return (now - lastMoving) >= stallDebounceSecs;
     }
 
+    /**
+     * Determines whether resynchronization has completed for both extension axes.
+     *
+     * @return {@code true} if the system is homing and both axes are homed, {@code false} otherwise
+     */
     public boolean isResyncComplete() {
         return systemState == SystemState.HOMING && leftHomed && rightHomed;
     }
 
+    /**
+     * Creates a command that resynchronizes both intake extension axes and stops them when complete.
+     *
+     * @return the resynchronization command
+     */
     public Command resyncCommand() {
         return startEnd(
                         () -> setWantedState(WantedState.RESYNC),
@@ -482,6 +562,11 @@ public class IntakeExtension implements Subsystem {
     @Getter private final Right right;
     @Getter private final IntakeExtensionConfig config;
 
+    /**
+     * Initializes the intake extension subsystem with its left and right axis configurations.
+     *
+     * @param config the configuration for both intake extension axes
+     */
     public IntakeExtension(IntakeExtensionConfig config) {
         this.config = config;
         this.left = new Left(config.getLeftConfig());
@@ -493,6 +578,9 @@ public class IntakeExtension implements Subsystem {
         Telemetry.print("Intake Extension Subsystem Initialized");
     }
 
+    /**
+     * Sets the initial encoder position for both extension axes from the configured position.
+     */
     private void setInitialPosition() {
         double initialRotations =
                 left.degreesToRotations(() -> config.getLeftConfig().getInitPosition());
@@ -500,28 +588,56 @@ public class IntakeExtension implements Subsystem {
         right.setInitialPosition(initialRotations);
     }
 
+    /**
+     * Resets both extension axes to their maximum positions.
+     */
     public void resetCurrentPositionToMax() {
         left.zeroAtMax();
         right.zeroAtMax();
     }
 
+    /**
+     * Creates a command that resets both extension axes to their maximum positions.
+     *
+     * @return a command that performs the position reset once
+     */
     public Command resetCurrentPositionToMaxCommand() {
         return new InstantCommand(this::resetCurrentPositionToMax);
     }
 
+    /**
+     * Creates a command that resets both extension axes to their initial positions.
+     *
+     * @return a command that sets the initial encoder positions
+     */
     public Command resetToInitialPos() {
         return new InstantCommand(this::setInitialPosition);
     }
 
+    /**
+     * Sets the brake mode for both intake extension axes.
+     *
+     * @param isInBrake whether to enable brake mode
+     */
     public void setBrakeMode(boolean isInBrake) {
         left.setBrakeMode(isInBrake);
         right.setBrakeMode(isInBrake);
     }
 
+    /**
+     * Provides the simulation model for the left intake extension axis.
+     *
+     * @return the left intake extension simulation model
+     */
     public Left.IntakeExtensionSim getSim() {
         return left.getSim();
     }
 
+    /**
+     * Reports the extension position as a percentage of its configured range.
+     *
+     * @return the current extension position percentage
+     */
     public double getPositionPercentage() {
         return left.getPositionPercentage();
     }

--- a/src/main/java/frc/robot/subsystems/intakeExtension/IntakeExtension.java
+++ b/src/main/java/frc/robot/subsystems/intakeExtension/IntakeExtension.java
@@ -397,7 +397,8 @@ public class IntakeExtension implements Subsystem {
         if (Math.abs(left.getVelocityRPM()) >= cfg.getHomingStallRPM()) {
             leftLastMoving = now;
         }
-        return isStalled(now, leftLastMoving, cfg.getHomingMinTimeSecs(), cfg.getHomingStallDebounceSecs());
+        return isStalled(
+                now, leftLastMoving, cfg.getHomingMinTimeSecs(), cfg.getHomingStallDebounceSecs());
     }
 
     private boolean detectRightStall() {
@@ -406,10 +407,12 @@ public class IntakeExtension implements Subsystem {
         if (Math.abs(right.getVelocityRPM()) >= cfg.getHomingStallRPM()) {
             rightLastMoving = now;
         }
-        return isStalled(now, rightLastMoving, cfg.getHomingMinTimeSecs(), cfg.getHomingStallDebounceSecs());
+        return isStalled(
+                now, rightLastMoving, cfg.getHomingMinTimeSecs(), cfg.getHomingStallDebounceSecs());
     }
 
-    private boolean isStalled(double now, double lastMoving, double minTimeSecs, double stallDebounceSecs) {
+    private boolean isStalled(
+            double now, double lastMoving, double minTimeSecs, double stallDebounceSecs) {
         if (now < minTimeSecs) {
             return false;
         }

--- a/src/main/java/frc/robot/subsystems/intakeExtension/IntakeExtension.java
+++ b/src/main/java/frc/robot/subsystems/intakeExtension/IntakeExtension.java
@@ -1,8 +1,5 @@
 package frc.robot.subsystems.intakeExtension;
 
-import com.ctre.phoenix6.configs.TalonFXConfiguration;
-import com.ctre.phoenix6.configs.TalonFXConfigurator;
-import com.ctre.phoenix6.hardware.TalonFX;
 import com.ctre.phoenix6.sim.TalonFXSimState;
 import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj.Timer;
@@ -11,7 +8,10 @@ import edu.wpi.first.wpilibj.util.Color;
 import edu.wpi.first.wpilibj.util.Color8Bit;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
+import edu.wpi.first.wpilibj2.command.Subsystem;
 import frc.robot.RobotSim;
+import frc.robot.subsystems.intakeExtension.IntakeExtension.Left.LeftConfig;
+import frc.robot.subsystems.intakeExtension.IntakeExtension.Right.RightConfig;
 import frc.spectrumLib.hardware.Rio;
 import frc.spectrumLib.mechanism.Mechanism;
 import frc.spectrumLib.sim.LinearConfig;
@@ -22,128 +22,179 @@ import lombok.Getter;
 /**
  * The Intake Extension subsystem. Extends and retracts the fuel intake.
  *
- * <p>The deploy is a rack-and-pinion driven by two independent motors: a left axis (this class, CAN
- * id 7) and a right axis ({@link IntakeExtensionRight}, CAN id 6). Each side runs its own
- * closed-loop position control rather than one following the other, so a side that skips teeth on
- * the rack can be driven on its own to resync.
+ * <p>The deploy is a rack-and-pinion driven by two independent motors: a left axis (CAN id 4) and a
+ * right axis (CAN id 5). Each side runs its own closed-loop position control rather than one
+ * following the other, so a side that skips teeth on the rack can be driven on its own to resync.
  *
  * <p>Normal deploy/retract states command both axes to the same setpoint. The {@code RESYNC} state
  * re-establishes truth by driving each side independently into the fully-extended hard stop (using
  * a soft-limit-bypassing voltage), detecting the stall, and re-zeroing that side's encoder at
  * {@code maxRotations}. This recovers from a tooth skip, which otherwise leaves the motor encoder
  * reading a position the rack is no longer at.
+ *
+ * <p>This is a container for two independent {@link Mechanism}s rather than a {@code Mechanism}
+ * itself, so it implements {@link Subsystem} and registers directly. Without that registration the
+ * scheduler would never call {@link #periodic()} and the state machine would never run.
  */
-public class IntakeExtension extends Mechanism {
+public class IntakeExtension implements Subsystem {
 
-    public static class IntakeExtensionConfig extends Config {
+    public static class Left extends Mechanism {
 
-        @Getter private final double initPosition = 0;
-        @Getter private final double triggerTolerance = 0.317637;
+        public static class LeftConfig extends Config {
 
-        /* Intake Extension config settings */
-        @Getter private final double zeroSpeed = -0.1;
-        @Getter private final double holdMaxSpeedRPM = 18;
+            @Getter private final double initPosition = 0;
+            @Getter private final double triggerTolerance = 0.317637;
 
-        /* 11.5 in of travel over a 0.5010597711 in pitch radius */
-        @Getter private final double maxRotations = 3.652821;
-        @Getter private final double minRotations = 0.0;
+            @Getter private final double zeroSpeed = -0.1;
+            @Getter private final double holdMaxSpeedRPM = 18;
 
-        @Getter private final double supplyCurrentLimit = 80;
-        @Getter private final double statorCurrentLimit = 80;
-        @Getter private final double lowerSupplyCurrentLimit = 40;
-        @Getter private final double lowerSupplyCurrentTime = 1;
+            @Getter private final double maxRotations = 3.652821;
+            @Getter private final double minRotations = 0.0;
 
-        @Getter private final double positionKp = 4.2;
-        @Getter private final double positionKi = 0;
-        @Getter private final double positionKd = 0;
-        @Getter private final double positionKv = 0.39;
-        @Getter private final double positionKs = 0;
-        @Getter private final double positionKa = 0;
-        @Getter private final double positionKg = -0.017;
-        @Getter private final double gearRatio = 3.5;
-        @Getter private final double rampPeriod = 0.02;
+            @Getter private final double supplyCurrentLimit = 80;
+            @Getter private final double statorCurrentLimit = 80;
+            @Getter private final double lowerSupplyCurrentLimit = 40;
+            @Getter private final double lowerSupplyCurrentTime = 1;
 
-        /* 4 ft/s, 20 ft/s^2 (fast extend) and 2 ft/s, 10 ft/s^2 (everything else) */
-        @Getter private final double mmCruiseVelocity = 15.246559;
-        @Getter private final double mmAcceleration = 76.232794;
-        @Getter private final double mmJerk = 0;
-        @Getter private final double slowMmCruiseVelocity = 7.623279;
-        @Getter private final double slowMmAcceleration = 38.116397;
-        @Getter private final double slowMmJerk = 0;
+            @Getter private final double positionKp = 4.2;
+            @Getter private final double positionKi = 0;
+            @Getter private final double positionKd = 0;
+            @Getter private final double positionKv = 0.39;
+            @Getter private final double positionKs = 0;
+            @Getter private final double positionKa = 0;
+            @Getter private final double positionKg = -0.017;
+            @Getter private final double gearRatio = 3.5;
+            @Getter private final double rampPeriod = 0.02;
 
-        @Getter private final double sensorToMechanismRatio = 3.5;
-        @Getter private final double rotorToSensorRatio = 1;
-        @Getter private final double CANcoderRotorToSensorRatio = 1.7;
-        @Getter private final double CANcoderSensorToMechanismRatio = 1;
-        @Getter private final double CANcoderOffset = 0;
-        @Getter private final boolean CANcoderAttached = false;
+            @Getter private final double mmCruiseVelocity = 15.246559;
+            @Getter private final double mmAcceleration = 76.232794;
+            @Getter private final double mmJerk = 0;
+            @Getter private final double slowMmCruiseVelocity = 7.623279;
+            @Getter private final double slowMmAcceleration = 38.116397;
+            @Getter private final double slowMmJerk = 0;
 
-        /* Resync / stall-homing settings (toward the fully-extended hard stop) */
-        @Getter private final double homingVoltage = 6;
-        @Getter private final double homingStallRPM = 50.0;
-        @Getter private final double homingMinTimeSecs = 0.3;
-        @Getter private final double homingStallDebounceSecs = 0.15;
-        @Getter private final double homingTimeoutSecs = 3.0;
+            @Getter private final double homingVoltage = 6;
+            @Getter private final double homingStallRPM = 50.0;
+            @Getter private final double homingMinTimeSecs = 0.3;
+            @Getter private final double homingStallDebounceSecs = 0.15;
+            @Getter private final double homingTimeoutSecs = 3.0;
 
-        /* Sim Configs */
-        @Getter private final double intakeX = Units.inchesToMeters(70);
-        @Getter private final double intakeY = Units.inchesToMeters(23);
-        @Getter private final double extensionMass = 10.0;
-        @Getter private final double drumRadiusMeters = Units.inchesToMeters(0.5010597711);
-        @Getter private final double extensionGearing = 3.5;
-        @Getter private final double angle = 180;
-        @Getter private final double staticLength = 10;
-        @Getter private final double movingLength = 55;
-        @Getter private final double lineWidth = 20;
-        @Getter private final double maxExtensionHeight = 40;
+            @Getter private final double intakeX = Units.inchesToMeters(70);
+            @Getter private final double intakeY = Units.inchesToMeters(23);
+            @Getter private final double extensionMass = 10.0;
+            @Getter private final double drumRadiusMeters = Units.inchesToMeters(0.5010597711);
+            @Getter private final double extensionGearing = 3.5;
+            @Getter private final double angle = 180;
+            @Getter private final double staticLength = 10;
+            @Getter private final double movingLength = 55;
+            @Getter private final double lineWidth = 20;
+            @Getter private final double maxExtensionHeight = 40;
 
-        public IntakeExtensionConfig() {
-            super("IntakeExtension", 4, Rio.CANIVORE);
-            configMinMaxRotations(minRotations, maxRotations);
-            configPIDGains(0, positionKp, positionKi, positionKd);
-            configFeedForwardGains(positionKs, positionKv, positionKa, positionKg);
-            configMotionMagic(mmCruiseVelocity, mmAcceleration, mmJerk);
-            configGravityType(false);
-            configOpenLoopRamps(rampPeriod);
-            configClosedLoopRamps(rampPeriod);
-            configSupplyCurrentLimit(supplyCurrentLimit, true);
-            configStatorCurrentLimit(statorCurrentLimit, true);
-            configLowerSupplyCurrentLimit(lowerSupplyCurrentLimit);
-            configLowerSupplyCurrentTime(lowerSupplyCurrentTime);
-            configGearRatio(gearRatio);
-            configForwardTorqueCurrentLimit(statorCurrentLimit);
-            configReverseTorqueCurrentLimit(statorCurrentLimit);
-            configForwardSoftLimit(maxRotations, true);
-            configReverseSoftLimit(minRotations, true);
-            configNeutralBrakeMode(false);
-            configClockwise_Positive();
+            public LeftConfig() {
+                super("IntakeExtensionLeft", 4, Rio.CANIVORE);
+                configMinMaxRotations(minRotations, maxRotations);
+                configPIDGains(0, positionKp, positionKi, positionKd);
+                configFeedForwardGains(positionKs, positionKv, positionKa, positionKg);
+                configMotionMagic(mmCruiseVelocity, mmAcceleration, mmJerk);
+                configGravityType(false);
+                configOpenLoopRamps(rampPeriod);
+                configClosedLoopRamps(rampPeriod);
+                configSupplyCurrentLimit(supplyCurrentLimit, true);
+                configStatorCurrentLimit(statorCurrentLimit, true);
+                configLowerSupplyCurrentLimit(lowerSupplyCurrentLimit);
+                configLowerSupplyCurrentTime(lowerSupplyCurrentTime);
+                configGearRatio(gearRatio);
+                configForwardTorqueCurrentLimit(statorCurrentLimit);
+                configReverseTorqueCurrentLimit(statorCurrentLimit);
+                configForwardSoftLimit(maxRotations, true);
+                configReverseSoftLimit(minRotations, true);
+                configNeutralBrakeMode(false);
+                configClockwise_Positive();
+            }
         }
 
-        public IntakeExtensionConfig modifyMotorConfig(TalonFX motor) {
-            TalonFXConfigurator configurator = motor.getConfigurator();
-            TalonFXConfiguration talonConfigMod = getTalonConfig();
+        @Getter private final LeftConfig config;
+        @Getter private IntakeExtensionSim sim;
 
-            configurator.apply(talonConfigMod);
-            talonConfig = talonConfigMod;
-            return this;
+        public Left(LeftConfig config) {
+            super(config);
+            this.config = config;
+
+            simulationInit();
+            Telemetry.print(getName() + " Subsystem Initialized");
+        }
+
+        public void goToRotations(double rotations) {
+            setMMPosition(() -> rotations);
+        }
+
+        public void goToRotationsSlow(
+                double rotations, double cruiseVelocity, double acceleration, double jerk) {
+            setDynMMPositionVoltage(
+                    () -> rotations, () -> cruiseVelocity, () -> acceleration, () -> jerk);
+        }
+
+        public void driveHomingVoltage(double volts) {
+            setVoltageOutputNoSoftLimit(() -> volts);
+        }
+
+        public void setInitialPosition(double rotations) {
+            if (isAttached()) {
+                motor.setPosition(rotations);
+            }
+        }
+
+        public void zeroAtMax() {
+            setMotorPosition(() -> config.getMaxRotations());
+        }
+
+        public void stopAxis() {
+            stop();
+        }
+
+        @Override
+        public void periodic() {
+            logBatteryUsage();
+            Telemetry.log("IntakeExtensionLeft/CurrentCommand", getCurrentCommandName());
+            Telemetry.log("IntakeExtensionLeft/Voltage", getVoltage(), "volts");
+            Telemetry.log("IntakeExtensionLeft/StatorCurrent", getStatorCurrent(), "amps");
+            Telemetry.log("IntakeExtensionLeft/SupplyCurrent", getSupplyCurrent(), "amps");
+            Telemetry.log("IntakeExtensionLeft/Position", getPositionRotations(), "rotations");
+            Telemetry.log("IntakeExtensionLeft/RPM", getVelocityRPM(), "RPM");
+            Telemetry.log("IntakeExtensionLeft/Temp", getTemp(), "deg_C");
+        }
+
+        public void simulationInit() {
+            if (isAttached()) {
+                sim = new IntakeExtensionSim(RobotSim.leftView, motor.getSimState());
+            }
+        }
+
+        class IntakeExtensionSim extends LinearSim {
+            public IntakeExtensionSim(Mechanism2d mech, TalonFXSimState motorSim) {
+                super(
+                        new LinearConfig(
+                                        config.getIntakeX(),
+                                        config.getIntakeY(),
+                                        config.getExtensionGearing(),
+                                        config.getDrumRadiusMeters())
+                                .setAngle(config.getAngle())
+                                .setMovingLength(config.getMovingLength())
+                                .setStaticLength(config.getStaticLength())
+                                .setMaxHeight(config.getMaxExtensionHeight())
+                                .setLineWidth(config.getLineWidth())
+                                .setColor(new Color8Bit(Color.kLightGray)),
+                        mech,
+                        motorSim,
+                        config.getName());
+            }
         }
     }
 
-    // ================================================================================
-    // Right Axis — independent, closed-loop, mirror-mounted
-    // ================================================================================
-
-    /**
-     * The right deploy axis. A standalone {@link Mechanism} (not a follower) so it can be driven
-     * independently of the left during a resync. Gains, limits, and geometry mirror the left
-     * config; only the CAN id, name, and motor inversion differ (the right gearbox is mirrored, so
-     * it is {@code Clockwise_Positive} where the left is {@code CounterClockwise_Positive}, giving
-     * both axes the same "positive = extend" convention).
-     */
-    public static class IntakeExtensionRight extends Mechanism {
+    public static class Right extends Mechanism {
 
         public static class RightConfig extends Config {
-            public RightConfig(IntakeExtensionConfig left) {
+            public RightConfig(LeftConfig left) {
                 super("IntakeExtensionRight", 5, Rio.CANIVORE);
                 setAttached(left.isAttached());
                 configMinMaxRotations(left.getMinRotations(), left.getMaxRotations());
@@ -172,44 +223,38 @@ public class IntakeExtension extends Mechanism {
             }
         }
 
-        @Getter private final RightConfig rightConfig;
+        @Getter private final RightConfig config;
 
-        public IntakeExtensionRight(IntakeExtensionConfig leftConfig) {
-            super(new RightConfig(leftConfig));
-            this.rightConfig = (RightConfig) super.config;
+        public Right(RightConfig config) {
+            super(config);
+            this.config = config;
             Telemetry.print(getName() + " Subsystem Initialized");
         }
 
-        /** Closed-loop Motion Magic to an absolute rotation target. */
         public void goToRotations(double rotations) {
             setMMPosition(() -> rotations);
         }
 
-        /** Slow (dynamic Motion Magic voltage) move to a rotation target. */
         public void goToRotationsSlow(
                 double rotations, double cruiseVelocity, double acceleration, double jerk) {
             setDynMMPositionVoltage(
                     () -> rotations, () -> cruiseVelocity, () -> acceleration, () -> jerk);
         }
 
-        /** Open-loop voltage that bypasses soft limits. Used to drive into the hard stop. */
         public void driveHomingVoltage(double volts) {
             setVoltageOutputNoSoftLimit(() -> volts);
         }
 
-        /** Seeds this axis's encoder to a known starting position (rotations). */
         public void setInitialPosition(double rotations) {
             if (isAttached()) {
                 motor.setPosition(rotations);
             }
         }
 
-        /** Re-zeroes this axis at the fully-extended hard stop. */
         public void zeroAtMax() {
-            setMotorPosition(() -> rightConfig.getMaxRotations());
+            setMotorPosition(() -> config.getMaxRotations());
         }
 
-        /** Holds the axis (neutral output). */
         public void stopAxis() {
             stop();
         }
@@ -227,51 +272,15 @@ public class IntakeExtension extends Mechanism {
         }
     }
 
-    // ---- Subsystem plumbing ----
+    public static class IntakeExtensionConfig {
 
-    @Getter private final IntakeExtensionConfig config;
-    @Getter private IntakeExtensionSim sim;
-    private final IntakeExtensionRight right;
+        @Getter private final LeftConfig leftConfig;
+        @Getter private final RightConfig rightConfig;
 
-    public IntakeExtension(IntakeExtensionConfig config) {
-        super(config);
-        this.config = config;
-        this.right = new IntakeExtensionRight(config);
-
-        setInitialPosition();
-
-        simulationInit();
-        Telemetry.print(getName() + " Subsystem Initialized");
-    }
-
-    private void setInitialPosition() {
-        if (isAttached()) {
-            double initialRotations = degreesToRotations(() -> config.getInitPosition());
-            motor.setPosition(initialRotations);
-            right.setInitialPosition(initialRotations);
+        public IntakeExtensionConfig(LeftConfig leftConfig, RightConfig rightConfig) {
+            this.leftConfig = leftConfig;
+            this.rightConfig = rightConfig;
         }
-    }
-
-    public void resetCurrentPositionToMax() {
-        if (isAttached()) {
-            motor.setPosition(config.getMaxRotations());
-        }
-        if (right.isAttached()) right.zeroAtMax();
-    }
-
-    public Command resetCurrentPositionToMaxCommand() {
-        return new InstantCommand(this::resetCurrentPositionToMax);
-    }
-
-    public Command resetToInitialPos() {
-        return new InstantCommand(this::setInitialPosition);
-    }
-
-    /** Sets brake mode on both deploy axes. */
-    @Override
-    public void setBrakeMode(boolean isInBrake) {
-        super.setBrakeMode(isInBrake);
-        if (right.isAttached()) right.setBrakeMode(isInBrake);
     }
 
     // ---- State Machine ----
@@ -336,36 +345,28 @@ public class IntakeExtension extends Mechanism {
                 applyHoming();
                 break;
             case STOPPED:
-                stop();
-                if (right.isAttached()) right.stopAxis();
+                left.stopAxis();
+                right.stopAxis();
                 return;
         }
     }
 
-    /**
-     * Commands both axes to the same position.
-     *
-     * @param percent target as a percentage of max rotations (0–100)
-     * @param slow whether to use the slow (dynamic Motion Magic voltage) profile
-     */
     private void commandBoth(double percent, boolean slow) {
-        final double rotations = percentToRotations(() -> percent);
+        final double rotations = left.percentToRotations(() -> percent);
         if (slow) {
-            setDynMMPositionVoltage(
-                    () -> rotations,
-                    () -> config.getSlowMmCruiseVelocity(),
-                    () -> config.getSlowMmAcceleration(),
-                    () -> config.getSlowMmJerk());
-            if (right.isAttached()) {
-                right.goToRotationsSlow(
-                        rotations,
-                        config.getSlowMmCruiseVelocity(),
-                        config.getSlowMmAcceleration(),
-                        config.getSlowMmJerk());
-            }
+            left.goToRotationsSlow(
+                    rotations,
+                    config.getLeftConfig().getSlowMmCruiseVelocity(),
+                    config.getLeftConfig().getSlowMmAcceleration(),
+                    config.getLeftConfig().getSlowMmJerk());
+            right.goToRotationsSlow(
+                    rotations,
+                    config.getLeftConfig().getSlowMmCruiseVelocity(),
+                    config.getLeftConfig().getSlowMmAcceleration(),
+                    config.getLeftConfig().getSlowMmJerk());
         } else {
-            setMMPosition(() -> rotations);
-            if (right.isAttached()) right.goToRotations(rotations);
+            left.goToRotations(rotations);
+            right.goToRotations(rotations);
         }
     }
 
@@ -374,19 +375,10 @@ public class IntakeExtension extends Mechanism {
     private final Timer homingTimer = new Timer();
     private boolean leftHomed = false;
     private boolean rightHomed = false;
-    // Timestamp (homingTimer seconds) each side was last seen moving above the stall speed.
     private double leftLastMoving = 0;
     private double rightLastMoving = 0;
 
-    /**
-     * Drives each side independently into the fully-extended hard stop, re-zeroing that side's
-     * encoder at {@code maxRotations} once it stalls. A tooth skip corrupts the motor encoder, so
-     * the hard stop is the only reliable position truth; homing uses a soft-limit-bypassing voltage
-     * so it can reach the physical stop even when the (stale) encoder thinks the soft limit is
-     * already reached.
-     */
     private void applyHoming() {
-        // Re-arm on entry to the HOMING state.
         if (previousSystemState != SystemState.HOMING) {
             homingTimer.restart();
             leftHomed = false;
@@ -395,23 +387,23 @@ public class IntakeExtension extends Mechanism {
             rightLastMoving = 0;
         }
 
-        boolean timedOut = homingTimer.get() >= config.getHomingTimeoutSecs();
+        double homingTimeout = config.getLeftConfig().getHomingTimeoutSecs();
+        double homingVoltage = config.getLeftConfig().getHomingVoltage();
+        boolean timedOut = homingTimer.get() >= homingTimeout;
 
-        // ── Left side (this mechanism) ──
         if (!leftHomed) {
             if (detectLeftStall() || timedOut) {
                 if (timedOut) Telemetry.print("IntakeExtension: LEFT resync timed out");
-                setMotorPosition(() -> config.getMaxRotations());
-                stop();
+                left.zeroAtMax();
+                left.stopAxis();
                 leftHomed = true;
             } else {
-                setVoltageOutputNoSoftLimit(() -> config.getHomingVoltage());
+                left.driveHomingVoltage(homingVoltage);
             }
         } else {
-            stop();
+            left.stopAxis();
         }
 
-        // ── Right side (independent axis) ──
         if (right.isAttached()) {
             if (!rightHomed) {
                 if (detectRightStall() || timedOut) {
@@ -420,19 +412,20 @@ public class IntakeExtension extends Mechanism {
                     right.stopAxis();
                     rightHomed = true;
                 } else {
-                    right.driveHomingVoltage(config.getHomingVoltage());
+                    right.driveHomingVoltage(homingVoltage);
                 }
             } else {
                 right.stopAxis();
             }
         } else {
-            rightHomed = true; // no right axis attached → nothing to resync
+            rightHomed = true;
         }
     }
 
     private boolean detectLeftStall() {
         double now = homingTimer.get();
-        if (Math.abs(getVelocityRPM()) >= config.getHomingStallRPM()) {
+        double stallRPM = config.getLeftConfig().getHomingStallRPM();
+        if (Math.abs(left.getVelocityRPM()) >= stallRPM) {
             leftLastMoving = now;
         }
         return isStalled(now, leftLastMoving);
@@ -440,35 +433,26 @@ public class IntakeExtension extends Mechanism {
 
     private boolean detectRightStall() {
         double now = homingTimer.get();
-        if (Math.abs(right.getVelocityRPM()) >= config.getHomingStallRPM()) {
+        double stallRPM = config.getLeftConfig().getHomingStallRPM();
+        if (Math.abs(right.getVelocityRPM()) >= stallRPM) {
             rightLastMoving = now;
         }
         return isStalled(now, rightLastMoving);
     }
 
-    /**
-     * A side is stalled once it has gone the debounce window without moving above the stall speed,
-     * but only after the minimum drive time has elapsed (so the initial pre-motion zero velocity is
-     * not mistaken for a stall).
-     */
     private boolean isStalled(double now, double lastMoving) {
-        if (now < config.getHomingMinTimeSecs()) {
+        double minTime = config.getLeftConfig().getHomingMinTimeSecs();
+        double debounce = config.getLeftConfig().getHomingStallDebounceSecs();
+        if (now < minTime) {
             return false;
         }
-        return (now - lastMoving) >= config.getHomingStallDebounceSecs();
+        return (now - lastMoving) >= debounce;
     }
 
-    /** Whether the most recent resync has finished homing both sides. */
     public boolean isResyncComplete() {
         return systemState == SystemState.HOMING && leftHomed && rightHomed;
     }
 
-    /**
-     * Runs a full resync: drives both sides into the extended hard stop, re-zeros each, then
-     * returns the subsystem to {@code STOPPED}.
-     *
-     * @return a command that completes once both sides are re-zeroed
-     */
     public Command resyncCommand() {
         return startEnd(
                         () -> setWantedState(WantedState.RESYNC),
@@ -477,52 +461,66 @@ public class IntakeExtension extends Mechanism {
                 .withName("IntakeExtension.resync");
     }
 
+    // ---- Subsystem plumbing ----
+
+    @Getter private final Left left;
+    @Getter private final Right right;
+    @Getter private final IntakeExtensionConfig config;
+
+    public IntakeExtension(IntakeExtensionConfig config) {
+        this.config = config;
+        this.left = new Left(config.getLeftConfig());
+        this.right = new Right(config.getRightConfig());
+
+        setInitialPosition();
+
+        this.register();
+        Telemetry.print("Intake Extension Subsystem Initialized");
+    }
+
+    private void setInitialPosition() {
+        double initialRotations =
+                left.degreesToRotations(() -> config.getLeftConfig().getInitPosition());
+        left.setInitialPosition(initialRotations);
+        right.setInitialPosition(initialRotations);
+    }
+
+    public void resetCurrentPositionToMax() {
+        left.zeroAtMax();
+        right.zeroAtMax();
+    }
+
+    public Command resetCurrentPositionToMaxCommand() {
+        return new InstantCommand(this::resetCurrentPositionToMax);
+    }
+
+    public Command resetToInitialPos() {
+        return new InstantCommand(this::setInitialPosition);
+    }
+
+    public void setBrakeMode(boolean isInBrake) {
+        left.setBrakeMode(isInBrake);
+        right.setBrakeMode(isInBrake);
+    }
+
+    public Left.IntakeExtensionSim getSim() {
+        return left.getSim();
+    }
+
+    public double getPositionPercentage() {
+        return left.getPositionPercentage();
+    }
+
     @Override
     public void periodic() {
         systemState = handleStateTransition();
         applyStates();
-        logBatteryUsage();
+
         Telemetry.log("IntakeExtension/WantedState", wantedState.toString());
         Telemetry.log("IntakeExtension/SystemState", systemState.toString());
-        Telemetry.log("IntakeExtension/CurrentCommand", getCurrentCommandName());
-        Telemetry.log("IntakeExtension/Voltage", getVoltage(), "volts");
-        Telemetry.log("IntakeExtension/StatorCurrent", getStatorCurrent(), "amps");
-        Telemetry.log("IntakeExtension/SupplyCurrent", getSupplyCurrent(), "amps");
-        Telemetry.log("IntakeExtension/Position", getPositionRotations(), "rotations");
-        Telemetry.log("IntakeExtension/RPM", getVelocityRPM(), "RPM");
-        Telemetry.log("IntakeExtension/Temp", getTemp(), "deg_C");
         Telemetry.log("IntakeExtension/LeftHomed", leftHomed);
         Telemetry.log("IntakeExtension/RightHomed", rightHomed);
 
         previousSystemState = systemState;
-    }
-
-    // --------------------------------------------------------------------------------
-    // Simulation
-    // --------------------------------------------------------------------------------
-    public void simulationInit() {
-        if (isAttached()) {
-            sim = new IntakeExtensionSim(RobotSim.leftView, motor.getSimState());
-        }
-    }
-
-    class IntakeExtensionSim extends LinearSim {
-        public IntakeExtensionSim(Mechanism2d mech, TalonFXSimState intakeExtensionMotorSim) {
-            super(
-                    new LinearConfig(
-                                    config.getIntakeX(),
-                                    config.getIntakeY(),
-                                    config.getExtensionGearing(),
-                                    config.getDrumRadiusMeters())
-                            .setAngle(config.getAngle())
-                            .setMovingLength(config.getMovingLength())
-                            .setStaticLength(config.getStaticLength())
-                            .setMaxHeight(config.getMaxExtensionHeight())
-                            .setLineWidth(config.getLineWidth())
-                            .setColor(new Color8Bit(Color.kLightGray)),
-                    mech,
-                    intakeExtensionMotorSim,
-                    config.getName());
-        }
     }
 }

--- a/src/main/java/frc/robot/subsystems/intakeExtension/IntakeExtension.java
+++ b/src/main/java/frc/robot/subsystems/intakeExtension/IntakeExtension.java
@@ -108,11 +108,6 @@ public class IntakeExtension implements Subsystem {
         }
 
         @Override
-        public void stop() {
-            super.stop();
-        }
-
-        @Override
         public void periodic() {
             logBatteryUsage();
             String prefix = getName() + "/";
@@ -125,28 +120,38 @@ public class IntakeExtension implements Subsystem {
             Telemetry.log(prefix + "Temp", getTemp(), "deg_C");
         }
 
+        /** Closed-loop Motion Magic to an absolute rotation target. */
         public void goToRotations(double rotations) {
             setMMPosition(() -> rotations);
         }
 
+        /** Slow (dynamic Motion Magic voltage) move to a rotation target. */
         public void goToRotationsSlow(
                 double rotations, double cruiseVelocity, double acceleration, double jerk) {
             setDynMMPositionVoltage(
                     () -> rotations, () -> cruiseVelocity, () -> acceleration, () -> jerk);
         }
 
+        /** Open-loop voltage that bypasses soft limits. Used to drive into the hard stop. */
         public void driveHomingVoltage(double volts) {
             setVoltageOutputNoSoftLimit(() -> volts);
         }
 
+        /** Seeds this axis's encoder to a known starting position (rotations). */
         public void setInitialPosition(double rotations) {
             if (isAttached()) {
                 motor.setPosition(rotations);
             }
         }
 
+        /** Re-zeroes this axis at the fully-extended hard stop. */
         public void zeroAtMax() {
             setMotorPosition(() -> config.getMaxRotations());
+        }
+
+        /** Holds the axis (neutral output). */
+        public void leftStop() {
+            stop();
         }
 
         public void simulationInit() {
@@ -230,11 +235,6 @@ public class IntakeExtension implements Subsystem {
         }
 
         @Override
-        public void stop() {
-            super.stop();
-        }
-
-        @Override
         public void periodic() {
             logBatteryUsage();
             String prefix = getName() + "/";
@@ -247,28 +247,38 @@ public class IntakeExtension implements Subsystem {
             Telemetry.log(prefix + "Temp", getTemp(), "deg_C");
         }
 
+        /** Closed-loop Motion Magic to an absolute rotation target. */
         public void goToRotations(double rotations) {
             setMMPosition(() -> rotations);
         }
 
+        /** Slow (dynamic Motion Magic voltage) move to a rotation target. */
         public void goToRotationsSlow(
                 double rotations, double cruiseVelocity, double acceleration, double jerk) {
             setDynMMPositionVoltage(
                     () -> rotations, () -> cruiseVelocity, () -> acceleration, () -> jerk);
         }
 
+        /** Open-loop voltage that bypasses soft limits. Used to drive into the hard stop. */
         public void driveHomingVoltage(double volts) {
             setVoltageOutputNoSoftLimit(() -> volts);
         }
 
+        /** Seeds this axis's encoder to a known starting position (rotations). */
         public void setInitialPosition(double rotations) {
             if (isAttached()) {
                 motor.setPosition(rotations);
             }
         }
 
+        /** Re-zeroes this axis at the fully-extended hard stop. */
         public void zeroAtMax() {
             setMotorPosition(() -> config.getMaxRotations());
+        }
+
+        /** Holds the axis (neutral output). */
+        public void rightStop() {
+            stop();
         }
     }
 
@@ -345,8 +355,8 @@ public class IntakeExtension implements Subsystem {
                 applyHoming();
                 break;
             case STOPPED:
-                left.stop();
-                right.stop();
+                left.leftStop();
+                right.rightStop();
                 return;
         }
     }
@@ -396,13 +406,13 @@ public class IntakeExtension implements Subsystem {
                 if (detectLeftStall() || timedOut) {
                     if (timedOut) Telemetry.print("IntakeExtension: LEFT resync timed out");
                     left.zeroAtMax();
-                    left.stop();
+                    left.leftStop();
                     leftHomed = true;
                 } else {
                     left.driveHomingVoltage(homingVoltage);
                 }
             } else {
-                left.stop();
+                left.leftStop();
             }
         } else {
             leftHomed = true;
@@ -413,13 +423,13 @@ public class IntakeExtension implements Subsystem {
                 if (detectRightStall() || timedOut) {
                     if (timedOut) Telemetry.print("IntakeExtension: RIGHT resync timed out");
                     right.zeroAtMax();
-                    right.stop();
+                    right.rightStop();
                     rightHomed = true;
                 } else {
                     right.driveHomingVoltage(homingVoltage);
                 }
             } else {
-                right.stop();
+                right.rightStop();
             }
         } else {
             rightHomed = true;

--- a/src/main/java/frc/robot/subsystems/intakeExtension/IntakeExtension.java
+++ b/src/main/java/frc/robot/subsystems/intakeExtension/IntakeExtension.java
@@ -137,10 +137,10 @@ public class IntakeExtension implements Subsystem {
         /**
          * Moves the axis to a rotation target using a dynamic motion profile.
          *
-         * @param rotations       the target position in rotations
-         * @param cruiseVelocity  the motion profile's cruise velocity
-         * @param acceleration    the motion profile's acceleration
-         * @param jerk            the motion profile's jerk
+         * @param rotations the target position in rotations
+         * @param cruiseVelocity the motion profile's cruise velocity
+         * @param acceleration the motion profile's acceleration
+         * @param jerk the motion profile's jerk
          */
         public void goToRotationsSlow(
                 double rotations, double cruiseVelocity, double acceleration, double jerk) {
@@ -170,9 +170,7 @@ public class IntakeExtension implements Subsystem {
             stop();
         }
 
-        /**
-         * Initializes the left extension axis simulation when the mechanism is attached.
-         */
+        /** Initializes the left extension axis simulation when the mechanism is attached. */
         public void simulationInit() {
             if (isAttached()) {
                 sim = new IntakeExtensionSim(RobotSim.leftView, motor.getSimState());
@@ -320,7 +318,7 @@ public class IntakeExtension implements Subsystem {
         /**
          * Creates an intake extension configuration from the configurations for both axes.
          *
-         * @param leftConfig  the left-axis configuration
+         * @param leftConfig the left-axis configuration
          * @param rightConfig the right-axis configuration
          */
         public IntakeExtensionConfig(LeftConfig leftConfig, RightConfig rightConfig) {
@@ -376,9 +374,7 @@ public class IntakeExtension implements Subsystem {
         };
     }
 
-    /**
-     * Applies the outputs associated with the current system state.
-     */
+    /** Applies the outputs associated with the current system state. */
     private void applyStates() {
         switch (systemState) {
             case FULL_EXTEND:
@@ -404,7 +400,7 @@ public class IntakeExtension implements Subsystem {
      * Commands both intake extension axes to the specified extension percentage.
      *
      * @param percent the target extension percentage
-     * @param slow    whether to use the slow motion profile
+     * @param slow whether to use the slow motion profile
      */
     private void commandBoth(double percent, boolean slow) {
         final double rotations = left.percentToRotations(() -> percent);
@@ -434,8 +430,8 @@ public class IntakeExtension implements Subsystem {
     private double rightLastMoving = 0;
 
     /**
-     * Drives both extension axes through the homing process and marks each axis complete when
-     * a stall is detected, the homing timeout is reached, or the axis is unattached.
+     * Drives both extension axes through the homing process and marks each axis complete when a
+     * stall is detected, the homing timeout is reached, or the axis is unattached.
      */
     private void applyHoming() {
         if (previousSystemState != SystemState.HOMING) {
@@ -489,7 +485,7 @@ public class IntakeExtension implements Subsystem {
      * Determines whether the left extension is stalled according to its homing thresholds.
      *
      * @return {@code true} if the minimum homing time has elapsed and the axis has remained below
-     *         the stall velocity threshold for the debounce period, {@code false} otherwise
+     *     the stall velocity threshold for the debounce period, {@code false} otherwise
      */
     private boolean detectLeftStall() {
         double now = homingTimer.get();
@@ -504,8 +500,8 @@ public class IntakeExtension implements Subsystem {
     /**
      * Determines whether the right extension axis has stalled during homing.
      *
-     * @return {@code true} if the axis has remained below the stall velocity threshold
-     *         for the required debounce period after the minimum homing time; {@code false} otherwise
+     * @return {@code true} if the axis has remained below the stall velocity threshold for the
+     *     required debounce period after the minimum homing time; {@code false} otherwise
      */
     private boolean detectRightStall() {
         double now = homingTimer.get();
@@ -520,11 +516,12 @@ public class IntakeExtension implements Subsystem {
     /**
      * Determines whether motion has remained below the stall threshold for the required duration.
      *
-     * @param now               the current homing time in seconds
-     * @param lastMoving        the most recent time motion was detected in seconds
-     * @param minTimeSecs       the minimum elapsed time before stall detection begins
+     * @param now the current homing time in seconds
+     * @param lastMoving the most recent time motion was detected in seconds
+     * @param minTimeSecs the minimum elapsed time before stall detection begins
      * @param stallDebounceSecs the required duration without motion before reporting a stall
-     * @return                  {@code true} if the minimum time has elapsed and the debounce duration has passed, {@code false} otherwise
+     * @return {@code true} if the minimum time has elapsed and the debounce duration has passed,
+     *     {@code false} otherwise
      */
     private boolean isStalled(
             double now, double lastMoving, double minTimeSecs, double stallDebounceSecs) {
@@ -544,7 +541,8 @@ public class IntakeExtension implements Subsystem {
     }
 
     /**
-     * Creates a command that resynchronizes both intake extension axes and stops them when complete.
+     * Creates a command that resynchronizes both intake extension axes and stops them when
+     * complete.
      *
      * @return the resynchronization command
      */
@@ -578,9 +576,7 @@ public class IntakeExtension implements Subsystem {
         Telemetry.print("Intake Extension Subsystem Initialized");
     }
 
-    /**
-     * Sets the initial encoder position for both extension axes from the configured position.
-     */
+    /** Sets the initial encoder position for both extension axes from the configured position. */
     private void setInitialPosition() {
         double initialRotations =
                 left.degreesToRotations(() -> config.getLeftConfig().getInitPosition());
@@ -588,9 +584,7 @@ public class IntakeExtension implements Subsystem {
         right.setInitialPosition(initialRotations);
     }
 
-    /**
-     * Resets both extension axes to their maximum positions.
-     */
+    /** Resets both extension axes to their maximum positions. */
     public void resetCurrentPositionToMax() {
         left.zeroAtMax();
         right.zeroAtMax();

--- a/src/main/java/frc/robot/subsystems/launcher/Launcher.java
+++ b/src/main/java/frc/robot/subsystems/launcher/Launcher.java
@@ -35,7 +35,7 @@ public class Launcher extends Mechanism {
         @Getter private double lowerSupplyCurrentLimit = 40;
         @Getter private double timeUntilLowerCurrent = 1;
         @Getter private double nominalVoltage = 16;
-        
+
         @Getter private double velocityKp = 0.5;
         @Getter private double velocityKv = 0.1425;
         @Getter private double velocityKs = 0;


### PR DESCRIPTION
Refactors `IntakeExtension.java` to follow the same structure and style as `DyeRotor.java` and `FuelIntake.java`.

### Changes

- **`IntakeExtension`** now implements `Subsystem` (container) instead of extending `Mechanism`
- **`Left`** and **`Right`** deploy axes are independent inner `Mechanism` classes, each with their own `Config`
- **`IntakeExtensionConfig`** holds `LeftConfig` and `RightConfig` (mirrors `DyeRotorConfig` / `FuelIntakeConfig`)
- Both axes share the same config values but remain independently controllable for resync
- Updated `Robot.Config` to create individual configs and pass them to the container config
- Updated all robot configs (PHOTON, FM, OM, PM, AM, XM) to set `attached` on left/right individually
- Preserved state machine, homing/resync logic, sim integration, and all public APIs (`setWantedState`, `resyncCommand`, `getSim`, `getPositionPercentage`, etc.)

Closes #117
Covers the IntakeExtension half of #118 (left/right independently controllable, DyeRotor-style). The Intake subsystem motor refactor from #118 is separate and untouched here, so #118 stays open until that lands too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Intake extension can now be operated as separate left and right sides, commanded together for consistent positioning.
  - Homing/resynchronization and stop behavior are now handled per side for improved alignment.
- **Configuration**
  - All supported robot setups were updated to use two detachable intake extension components (left and right).
- **Refactor**
  - Intake extension was reorganized into a multi-axis subsystem container to support independent per-side control and state handling.
- **Documentation**
  - Added clearer in-code documentation for DyeRotor behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
