### PR TITLE
Add unit tests for pure-logic utility and math classes

### DIFF
--- a/src/test/java/frc/rebuilt/FieldHelpersTest.java
+++ b/src/test/java/frc/rebuilt/FieldHelpersTest.java
@@ -1,0 +1,113 @@
+package frc.rebuilt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import edu.wpi.first.math.geometry.Rotation2d;
+import org.junit.jupiter.api.Test;
+
+class FieldHelpersTest {
+
+    @Test
+    void flipAngle_positive() {
+        assertEquals(190.0, FieldHelpers.flipAngle(10.0), 1e-9);
+    }
+
+    @Test
+    void flipAngle_180becomesZero() {
+        assertEquals(0.0, FieldHelpers.flipAngle(180.0), 1e-9);
+    }
+
+    @Test
+    void flipAngle_above360() {
+        assertEquals(130.0, FieldHelpers.flipAngle(310.0), 1e-9);
+    }
+
+    @Test
+    void flipAngle_zero() {
+        assertEquals(180.0, FieldHelpers.flipAngle(0.0), 1e-9);
+    }
+
+    @Test
+    void flipAngle_Rotation2d() {
+        Rotation2d result = FieldHelpers.flipAngle(Rotation2d.fromDegrees(45));
+        assertEquals(-135.0, result.getDegrees(), 1e-9);
+    }
+
+    @Test
+    void flipAngle_Rotation2d_zero() {
+        Rotation2d result = FieldHelpers.flipAngle(Rotation2d.fromDegrees(0));
+        assertEquals(180.0, result.getDegrees(), 1e-9);
+    }
+
+    @Test
+    void flipAngle_Rotation2d_negative() {
+        Rotation2d result = FieldHelpers.flipAngle(Rotation2d.fromDegrees(-90));
+        assertEquals(90.0, result.getDegrees(), 1e-9);
+    }
+
+    @Test
+    void normalizeAngle_alreadyInRange() {
+        assertEquals(1.0, FieldHelpers.normalizeAngle(1.0), 1e-9);
+    }
+
+    @Test
+    void normalizeAngle_abovePi() {
+        double result = FieldHelpers.normalizeAngle(Math.PI + 0.5);
+        assertTrue(result < Math.PI);
+        assertTrue(result > -Math.PI);
+    }
+
+    @Test
+    void normalizeAngle_belowNegativePi() {
+        double result = FieldHelpers.normalizeAngle(-Math.PI - 0.5);
+        assertTrue(result < Math.PI);
+        assertTrue(result > -Math.PI);
+    }
+
+    @Test
+    void normalizeAngle_exactPi_wrapsToNegativePi() {
+        double result = FieldHelpers.normalizeAngle(Math.PI);
+        assertEquals(-Math.PI, result, 1e-9);
+    }
+
+    @Test
+    void normalizeAngle_multiTurn() {
+        double result = FieldHelpers.normalizeAngle(4 * Math.PI + 0.1);
+        assertEquals(0.1, result, 1e-9);
+    }
+
+    @Test
+    void normalizeAngle_zero() {
+        assertEquals(0.0, FieldHelpers.normalizeAngle(0.0), 1e-9);
+    }
+
+    @Test
+    void poseOutOfField_xNegative() {
+        assertTrue(
+                FieldHelpers.poseOutOfField(
+                        new edu.wpi.first.math.geometry.Pose2d(-0.1, 4.0, new Rotation2d())));
+    }
+
+    @Test
+    void poseOutOfField_yNegative() {
+        assertTrue(
+                FieldHelpers.poseOutOfField(
+                        new edu.wpi.first.math.geometry.Pose2d(8.0, -0.1, new Rotation2d())));
+    }
+
+    @Test
+    void poseOutOfField_inside() {
+        assertFalse(
+                FieldHelpers.poseOutOfField(
+                        new edu.wpi.first.math.geometry.Pose2d(8.0, 4.0, new Rotation2d())));
+    }
+
+    @Test
+    void poseOutOfField_atBoundary_true() {
+        assertTrue(
+                FieldHelpers.poseOutOfField(
+                        new edu.wpi.first.math.geometry.Pose2d(0.0, 4.0, new Rotation2d())));
+    }
+}

--- a/src/test/java/frc/spectrumLib/util/CachedDoubleTest.java
+++ b/src/test/java/frc/spectrumLib/util/CachedDoubleTest.java
@@ -1,0 +1,79 @@
+package frc.spectrumLib.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class CachedDoubleTest {
+
+    @Test
+    void getAsDouble_returnsSourceValue() {
+        CachedDouble cached = new CachedDouble(() -> 42.0);
+        assertEquals(42.0, cached.getAsDouble(), 1e-9);
+    }
+
+    @Test
+    void getAsDouble_cachesUntilPeriodic() {
+        AtomicInteger callCount = new AtomicInteger(0);
+        CachedDouble cached =
+                new CachedDouble(
+                        () -> {
+                            callCount.incrementAndGet();
+                            return 3.14;
+                        });
+
+        assertEquals(3.14, cached.getAsDouble(), 1e-9);
+        assertEquals(3.14, cached.getAsDouble(), 1e-9);
+        assertEquals(3.14, cached.getAsDouble(), 1e-9);
+        assertEquals(1, callCount.get(), "source should be called only once before periodic()");
+    }
+
+    @Test
+    void periodic_invalidatesCache() {
+        AtomicInteger callCount = new AtomicInteger(0);
+        CachedDouble cached =
+                new CachedDouble(
+                        () -> {
+                            callCount.incrementAndGet();
+                            return 1.0;
+                        });
+
+        cached.getAsDouble();
+        assertEquals(1, callCount.get());
+
+        cached.periodic();
+        cached.getAsDouble();
+        assertEquals(2, callCount.get(), "periodic should force re-read on next getAsDouble");
+    }
+
+    @Test
+    void sourceChanges_betweenPeriodics() {
+        double[] value = {10.0};
+        CachedDouble cached = new CachedDouble(() -> value[0]);
+
+        assertEquals(10.0, cached.getAsDouble(), 1e-9);
+        value[0] = 20.0;
+        assertEquals(
+                10.0, cached.getAsDouble(), 1e-9, "cached value should not reflect source change");
+
+        cached.periodic();
+        assertEquals(
+                20.0,
+                cached.getAsDouble(),
+                1e-9,
+                "after periodic, should reflect new source value");
+    }
+
+    @Test
+    void negativeValue_preserved() {
+        CachedDouble cached = new CachedDouble(() -> -123.456);
+        assertEquals(-123.456, cached.getAsDouble(), 1e-9);
+    }
+
+    @Test
+    void zeroValue() {
+        CachedDouble cached = new CachedDouble(() -> 0.0);
+        assertEquals(0.0, cached.getAsDouble(), 1e-9);
+    }
+}

--- a/src/test/java/frc/spectrumLib/util/CanDeviceIdTest.java
+++ b/src/test/java/frc/spectrumLib/util/CanDeviceIdTest.java
@@ -1,0 +1,108 @@
+package frc.spectrumLib.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class CanDeviceIdTest {
+
+    @Test
+    void constructorWithBus() {
+        CanDeviceId id = new CanDeviceId(5, "canivore");
+        assertEquals(5, id.getDeviceNumber());
+        assertEquals("canivore", id.getBus());
+    }
+
+    @Test
+    void constructorDefaultBus() {
+        CanDeviceId id = new CanDeviceId(3);
+        assertEquals(3, id.getDeviceNumber());
+        assertEquals("", id.getBus());
+    }
+
+    @Test
+    void equals_sameDeviceSameBus() {
+        CanDeviceId a = new CanDeviceId(7, "rio");
+        CanDeviceId b = new CanDeviceId(7, "rio");
+        assertTrue(a.equals(b));
+    }
+
+    @Test
+    void equals_differentDeviceSameBus() {
+        CanDeviceId a = new CanDeviceId(7, "rio");
+        CanDeviceId b = new CanDeviceId(8, "rio");
+        assertFalse(a.equals(b));
+    }
+
+    @Test
+    void equals_sameDeviceDifferentBus() {
+        CanDeviceId a = new CanDeviceId(7, "rio");
+        CanDeviceId b = new CanDeviceId(7, "canivore");
+        assertFalse(a.equals(b));
+    }
+
+    @Test
+    void equals_null_false() {
+        CanDeviceId a = new CanDeviceId(7, "rio");
+        assertFalse(a.equals((Object) null));
+    }
+
+    @Test
+    void equals_sameInstance_true() {
+        CanDeviceId a = new CanDeviceId(7, "rio");
+        assertTrue(a.equals(a));
+    }
+
+    @Test
+    void equals_differentType_false() {
+        CanDeviceId a = new CanDeviceId(7, "rio");
+        assertFalse(a.equals("not a CanDeviceId"));
+    }
+
+    @Test
+    void equals_typedOverload() {
+        CanDeviceId a = new CanDeviceId(7, "rio");
+        CanDeviceId b = new CanDeviceId(7, "rio");
+        CanDeviceId c = new CanDeviceId(8, "rio");
+        assertTrue(a.equals(b));
+        assertFalse(a.equals(c));
+    }
+
+    @Test
+    void hashCode_equalInstances_equalHash() {
+        CanDeviceId a = new CanDeviceId(7, "rio");
+        CanDeviceId b = new CanDeviceId(7, "rio");
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    void hashCode_differentBus_differentHash() {
+        CanDeviceId a = new CanDeviceId(7, "rio");
+        CanDeviceId b = new CanDeviceId(7, "canivore");
+        assertNotEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    void equals_nullBus_same() {
+        CanDeviceId a = new CanDeviceId(5, null);
+        CanDeviceId b = new CanDeviceId(5, null);
+        assertTrue(a.equals(b));
+    }
+
+    @Test
+    void equals_nullBus_vs_nonNull() {
+        CanDeviceId a = new CanDeviceId(5, null);
+        CanDeviceId b = new CanDeviceId(5, "rio");
+        assertFalse(a.equals(b));
+    }
+
+    @Test
+    void equals_nonNullBus_vs_null() {
+        CanDeviceId a = new CanDeviceId(5, "rio");
+        CanDeviceId b = new CanDeviceId(5, null);
+        assertFalse(a.equals(b));
+    }
+}

--- a/src/test/java/frc/spectrumLib/util/ConversionsTest.java
+++ b/src/test/java/frc/spectrumLib/util/ConversionsTest.java
@@ -1,0 +1,62 @@
+package frc.spectrumLib.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.function.DoubleSupplier;
+import org.junit.jupiter.api.Test;
+
+class ConversionsTest {
+
+    @Test
+    void rpmToRps_positive() {
+        assertEquals(1.0, Conversions.RPMtoRPS(60.0), 1e-9);
+    }
+
+    @Test
+    void rpmToRps_zero() {
+        assertEquals(0.0, Conversions.RPMtoRPS(0.0), 1e-9);
+    }
+
+    @Test
+    void rpmToRps_negative() {
+        assertEquals(-1.0, Conversions.RPMtoRPS(-60.0), 1e-9);
+    }
+
+    @Test
+    void rpmToRps_fractional() {
+        assertEquals(0.5, Conversions.RPMtoRPS(30.0), 1e-9);
+    }
+
+    @Test
+    void rpmToRps_fromSupplier() {
+        DoubleSupplier supplier = () -> 120.0;
+        assertEquals(2.0, Conversions.RPMtoRPS(supplier), 1e-9);
+    }
+
+    @Test
+    void rpmToRps_fromSupplier_zero() {
+        DoubleSupplier supplier = () -> 0.0;
+        assertEquals(0.0, Conversions.RPMtoRPS(supplier), 1e-9);
+    }
+
+    @Test
+    void rpsToRpm_positive() {
+        assertEquals(60.0, Conversions.RPStoRPM(1.0), 1e-9);
+    }
+
+    @Test
+    void rpsToRpm_zero() {
+        assertEquals(0.0, Conversions.RPStoRPM(0.0), 1e-9);
+    }
+
+    @Test
+    void rpsToRpm_negative() {
+        assertEquals(-60.0, Conversions.RPStoRPM(-1.0), 1e-9);
+    }
+
+    @Test
+    void roundTrip_rpmToRpsToRpm() {
+        double original = 1234.567;
+        assertEquals(original, Conversions.RPStoRPM(Conversions.RPMtoRPS(original)), 1e-9);
+    }
+}

--- a/src/test/java/frc/spectrumLib/util/ExpCurveTest.java
+++ b/src/test/java/frc/spectrumLib/util/ExpCurveTest.java
@@ -1,0 +1,129 @@
+package frc.spectrumLib.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class ExpCurveTest {
+
+    @Test
+    void defaultConstructor_linearPassThrough() {
+        ExpCurve curve = new ExpCurve();
+        assertEquals(0.5, curve.calculate(0.5), 1e-9);
+        assertEquals(0.0, curve.calculate(0.0), 1e-9);
+        assertEquals(-0.5, curve.calculate(-0.5), 1e-9);
+    }
+
+    @Test
+    void defaultConstructor_inputAtOne() {
+        ExpCurve curve = new ExpCurve();
+        assertEquals(1.0, curve.calculate(1.0), 1e-9);
+    }
+
+    @Test
+    void defaultConstructor_inputAtNegativeOne() {
+        ExpCurve curve = new ExpCurve();
+        assertEquals(-1.0, curve.calculate(-1.0), 1e-9);
+    }
+
+    @Test
+    void exponentialCurve_reducesOutputs() {
+        ExpCurve curve = new ExpCurve(2.0, 0.0, 1.0, 0.0);
+        double result = curve.calculate(0.5);
+        assertTrue(result < 0.5);
+        assertTrue(result > 0.0);
+    }
+
+    @Test
+    void exponentialCurve_preservesSign() {
+        ExpCurve curve = new ExpCurve(2.0, 0.0, 1.0, 0.0);
+        assertTrue(curve.calculate(0.5) > 0.0);
+        assertTrue(curve.calculate(-0.5) < 0.0);
+    }
+
+    @Test
+    void scalar_applied() {
+        ExpCurve curve = new ExpCurve(1.0, 0.0, 0.5, 0.0);
+        assertEquals(0.25, curve.calculate(0.5), 1e-9);
+    }
+
+    @Test
+    void offset_applied() {
+        ExpCurve curve = new ExpCurve(1.0, 0.2, 1.0, 0.0);
+        assertEquals(0.7, curve.calculate(0.5), 1e-9);
+    }
+
+    @Test
+    void deadzone_createsZeroRegion() {
+        ExpCurve curve = new ExpCurve(1.0, 0.0, 1.0, 0.2);
+        assertEquals(0.0, curve.calculate(0.0), 1e-9);
+        assertEquals(0.0, curve.calculate(0.05), 1e-9);
+    }
+
+    @Test
+    void deadzone_remapsOutside() {
+        ExpCurve curve = new ExpCurve(1.0, 0.0, 1.0, 0.5);
+        assertEquals(1.0, curve.calculate(1.0), 1e-9);
+    }
+
+    @Test
+    void setExpVal_zeroOrNegative_clampsToOne() {
+        ExpCurve curve = new ExpCurve();
+        curve.setExpVal(0.0);
+        assertEquals(1.0, curve.getExpVal(), 1e-9);
+        curve.setExpVal(-3.0);
+        assertEquals(1.0, curve.getExpVal(), 1e-9);
+    }
+
+    @Test
+    void setExpVal_updatesGetter() {
+        ExpCurve curve = new ExpCurve();
+        curve.setExpVal(3.0);
+        assertEquals(3.0, curve.getExpVal(), 1e-9);
+    }
+
+    @Test
+    void getCurvePoints_returnsRequestedCount() {
+        ExpCurve curve = new ExpCurve();
+        double[][] points = curve.getCurvePoints(10);
+        assertEquals(10, points.length);
+    }
+
+    @Test
+    void getCurvePoints_range() {
+        ExpCurve curve = new ExpCurve();
+        double[][] points = curve.getCurvePoints(3);
+        assertEquals(-1.0, points[0][0], 1e-9);
+        assertEquals(0.0, points[1][0], 1e-9);
+        assertEquals(1.0, points[2][0], 1e-9);
+    }
+
+    @Test
+    void inherited_setOffset_getOffset() {
+        ExpCurve curve = new ExpCurve();
+        curve.setOffset(0.75);
+        assertEquals(0.75, curve.getOffset(), 1e-9);
+    }
+
+    @Test
+    void inherited_setScalar_getScalar() {
+        ExpCurve curve = new ExpCurve();
+        curve.setScalar(0.5);
+        assertEquals(0.5, curve.getScalar(), 1e-9);
+    }
+
+    @Test
+    void inherited_setDeadzone_getDeadzone() {
+        ExpCurve curve = new ExpCurve();
+        curve.setDeadzone(0.3);
+        assertEquals(0.3, curve.getDeadzone(), 1e-9);
+    }
+
+    @Test
+    void setDeadzone_abs_negativeInput() {
+        ExpCurve curve = new ExpCurve();
+        curve.setDeadzone(-0.4);
+        assertEquals(0.4, curve.getDeadzone(), 1e-9);
+    }
+}

--- a/src/test/java/frc/spectrumLib/util/TrioTest.java
+++ b/src/test/java/frc/spectrumLib/util/TrioTest.java
@@ -1,0 +1,60 @@
+package frc.spectrumLib.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+class TrioTest {
+
+    @Test
+    void constructorAndGetters() {
+        Trio<String, Integer, Double> trio = new Trio<>("first", 42, 3.14);
+        assertEquals("first", trio.getFirst());
+        assertEquals(42, trio.getSecond());
+        assertEquals(3.14, trio.getThird());
+    }
+
+    @Test
+    void getFirst_returnsConstructorArg() {
+        Trio<Integer, String, Boolean> trio = new Trio<>(100, "mid", true);
+        assertEquals(100, trio.getFirst());
+    }
+
+    @Test
+    void getSecond_returnsConstructorArg() {
+        Trio<Integer, String, Boolean> trio = new Trio<>(100, "mid", true);
+        assertEquals("mid", trio.getSecond());
+    }
+
+    @Test
+    void getThird_returnsConstructorArg() {
+        Trio<Integer, String, Boolean> trio = new Trio<>(100, "mid", true);
+        assertEquals(true, trio.getThird());
+    }
+
+    @Test
+    void staticOf_createsTrio() {
+        Trio<Double, Double, Double> trio = Trio.of(1.0, 2.0, 3.0);
+        assertNotNull(trio);
+        assertEquals(1.0, trio.getFirst());
+        assertEquals(2.0, trio.getSecond());
+        assertEquals(3.0, trio.getThird());
+    }
+
+    @Test
+    void nullValues_preserved() {
+        Trio<String, String, String> trio = new Trio<>(null, "b", null);
+        assertEquals(null, trio.getFirst());
+        assertEquals("b", trio.getSecond());
+        assertEquals(null, trio.getThird());
+    }
+
+    @Test
+    void mixedTypes() {
+        Trio<Long, Character, Object> trio = Trio.of(123L, 'x', new Object());
+        assertEquals(123L, trio.getFirst());
+        assertEquals('x', trio.getSecond());
+        assertNotNull(trio.getThird());
+    }
+}

--- a/src/test/java/frc/spectrumLib/util/UtilTest.java
+++ b/src/test/java/frc/spectrumLib/util/UtilTest.java
@@ -1,0 +1,187 @@
+package frc.spectrumLib.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class UtilTest {
+
+    @Test
+    void limit_symmetric_withinRange() {
+        assertEquals(5.0, Util.limit(5.0, 10.0), 1e-9);
+    }
+
+    @Test
+    void limit_symmetric_atPositiveBound() {
+        assertEquals(10.0, Util.limit(10.0, 10.0), 1e-9);
+    }
+
+    @Test
+    void limit_symmetric_atNegativeBound() {
+        assertEquals(-10.0, Util.limit(-10.0, 10.0), 1e-9);
+    }
+
+    @Test
+    void limit_symmetric_aboveMax() {
+        assertEquals(10.0, Util.limit(15.0, 10.0), 1e-9);
+    }
+
+    @Test
+    void limit_symmetric_belowMin() {
+        assertEquals(-10.0, Util.limit(-15.0, 10.0), 1e-9);
+    }
+
+    @Test
+    void limit_threeArg_withinRange() {
+        assertEquals(3.0, Util.limit(3.0, 1.0, 5.0), 1e-9);
+    }
+
+    @Test
+    void limit_threeArg_atMax() {
+        assertEquals(5.0, Util.limit(10.0, 1.0, 5.0), 1e-9);
+    }
+
+    @Test
+    void limit_threeArg_atMin() {
+        assertEquals(1.0, Util.limit(0.0, 1.0, 5.0), 1e-9);
+    }
+
+    @Test
+    void inRange_symmetric_inside() {
+        assertTrue(Util.inRange(3.0, 10.0));
+    }
+
+    @Test
+    void inRange_symmetric_atBound_false() {
+        assertFalse(Util.inRange(10.0, 10.0));
+        assertFalse(Util.inRange(-10.0, 10.0));
+    }
+
+    @Test
+    void inRange_symmetric_outside() {
+        assertFalse(Util.inRange(15.0, 10.0));
+        assertFalse(Util.inRange(-15.0, 10.0));
+    }
+
+    @Test
+    void inRange_threeArg_inside() {
+        assertTrue(Util.inRange(3.0, 1.0, 5.0));
+    }
+
+    @Test
+    void inRange_threeArg_atBound_false() {
+        assertFalse(Util.inRange(1.0, 1.0, 5.0));
+        assertFalse(Util.inRange(5.0, 1.0, 5.0));
+    }
+
+    @Test
+    void inRange_threeArg_belowMin() {
+        assertFalse(Util.inRange(0.0, 1.0, 5.0));
+    }
+
+    @Test
+    void inRange_threeArg_aboveMax() {
+        assertFalse(Util.inRange(6.0, 1.0, 5.0));
+    }
+
+    @Test
+    void interpolate_midpoint() {
+        assertEquals(5.0, Util.interpolate(0.0, 10.0, 0.5), 1e-9);
+    }
+
+    @Test
+    void interpolate_start() {
+        assertEquals(0.0, Util.interpolate(0.0, 10.0, 0.0), 1e-9);
+    }
+
+    @Test
+    void interpolate_end() {
+        assertEquals(10.0, Util.interpolate(0.0, 10.0, 1.0), 1e-9);
+    }
+
+    @Test
+    void interpolate_clampBelow() {
+        assertEquals(0.0, Util.interpolate(0.0, 10.0, -0.5), 1e-9);
+    }
+
+    @Test
+    void interpolate_clampAbove() {
+        assertEquals(10.0, Util.interpolate(0.0, 10.0, 1.5), 1e-9);
+    }
+
+    @Test
+    void epsilonEquals_double_default() {
+        assertTrue(Util.epsilonEquals(1.0, 1.0));
+        assertTrue(Util.epsilonEquals(1.0, 1.0 + 1e-13));
+        assertFalse(Util.epsilonEquals(1.0, 1.0 + 1e-11));
+    }
+
+    @Test
+    void epsilonEquals_double_customEpsilon() {
+        assertTrue(Util.epsilonEquals(1.0, 1.1, 0.2));
+        assertFalse(Util.epsilonEquals(1.0, 1.3, 0.2));
+    }
+
+    @Test
+    void epsilonEquals_int_differenceWithinEpsilon() {
+        assertTrue(Util.epsilonEquals(5, 7, 3));
+    }
+
+    @Test
+    void epsilonEquals_int_differenceOutsideEpsilon() {
+        assertFalse(Util.epsilonEquals(5, 10, 3));
+    }
+
+    @Test
+    void epsilonEquals_int_exactMatch() {
+        assertTrue(Util.epsilonEquals(5, 5, 0));
+    }
+
+    @Test
+    void allCloseTo_allWithinEpsilon() {
+        List<Double> list = List.of(1.0, 1.0 + 1e-13, 1.0 - 1e-13);
+        assertTrue(Util.allCloseTo(list, 1.0, 1e-10));
+    }
+
+    @Test
+    void allCloseTo_oneOutside() {
+        List<Double> list = List.of(1.0, 2.0, 1.0);
+        assertFalse(Util.allCloseTo(list, 1.0, 0.5));
+    }
+
+    @Test
+    void allCloseTo_emptyList_true() {
+        List<Double> list = Collections.emptyList();
+        assertTrue(Util.allCloseTo(list, 1.0, 1e-10));
+    }
+
+    @Test
+    void joinStrings_basic() {
+        assertEquals("a, b, c", Util.joinStrings(", ", List.of("a", "b", "c")));
+    }
+
+    @Test
+    void joinStrings_customDelimiter() {
+        assertEquals("a--b--c", Util.joinStrings("--", List.of("a", "b", "c")));
+    }
+
+    @Test
+    void joinStrings_emptyList() {
+        assertEquals("", Util.joinStrings(", ", new ArrayList<>()));
+    }
+
+    @Test
+    void joinStrings_numbers() {
+        assertEquals("1|2|3", Util.joinStrings("|", List.of(1, 2, 3)));
+    }
+
+    @Test
+    void joinStrings_singleElement() {
+        assertEquals("hello", Util.joinStrings(", ", List.of("hello")));
+    }
+}


### PR DESCRIPTION
Closes #120

Adds 104 unit tests across 7 test files for the pure-logic classes that need no hardware mocking:

- **Conversions** — RPM/RPS conversions and round-trip
- **Trio** — generic trio data structure
- **CanDeviceId** — CAN device identity, equality, and hashing
- **Util** — limit, inRange, interpolate, epsilonEquals, allCloseTo, joinStrings
- **ExpCurve** — exponential stick curve, deadzone, offset, scalar
- **CachedDouble** — value caching and periodic invalidation
- **FieldHelpers** — flipAngle, normalizeAngle, poseOutOfField

All tests pass with `./gradlew test`.